### PR TITLE
Added gulp-bower into the gulp build process.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,7 +106,7 @@ gulp.task('fonts', function () {
 // });
 
 // vulcanize main site elements separately.
-gulp.task('vulcanize-elements', ['clean', 'bower', 'compass'], function() {
+gulp.task('vulcanize-elements', ['clean', 'compass'], function() {
   return gulp.src([
       APP_DIR + '/elements/elements.html'
     ], {base: './'})
@@ -200,7 +200,7 @@ gulp.task('pagespeed', pagespeed.bind(null, {
 }));
 
 // Watch Files For Changes & Reload
-gulp.task('serve', ['bower', 'compass'], function() {
+gulp.task('serve', ['compass'], function() {
   browserSync({
     notify: false,
     // Run as an https by uncommenting 'https: true'
@@ -226,6 +226,10 @@ gulp.task('default', ['clean'], function(cb) {
 
 gulp.task('bower', function() {
   return bower({cwd: APP_DIR});
+});
+
+gulp.task('setup', function(cb) {
+  runSequence('bower', 'default', cb);
 });
 
 // Load custom tasks from the `tasks` directory

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "del": "^0.1.3",
     "gulp": "^3.8.8",
     "gulp-autoprefixer": "^2.0.0",
+    "gulp-bower": "^0.0.7",
     "gulp-cache": "^0.2.2",
     "gulp-changed": "^1.0.0",
     "gulp-csso": "^0.2.9",


### PR DESCRIPTION
R: @ebidel 

This seems useful to me, but I don't have a whole lot of experience with `gulp` best practices...

`npm install --save-dev gulp-bower` alphabetized the dependency list in `package.json`, so most of the changes there are incidental.
