### PR TITLE
Private CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,11 @@
+image: bradrydzewski/node:0.10
+git:
+  depth: 1
+script:
+  - npm -q install
+  - npm -q -g install gulp
+  - gem install compass --no-ri --no-doc
+  - rbenv rehash
+  - gulp bower
+  - gulp
+


### PR DESCRIPTION
This is based on drone.io opensource version and should help us keep an eye on build success/failure when merging. I will also add "auto-deploy to appspot on green" later.

The CI is here: https://ci.cloudware.io/github.com/GoogleChrome/ioweb2015 but it should also show up in pull requests. People in ioweb-core should have access.

This is a temporary solution until we open the repo. We'll then switch to a public CI.
