### PR TITLE
Remove compass from drone CI config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,8 +4,6 @@ git:
 script:
   - npm -q install
   - npm -q -g install gulp
-  - gem install compass --no-ri --no-doc
-  - rbenv rehash
   - gulp bower
   - gulp
 


### PR DESCRIPTION
Now that we use libsass, no need to install compass for drone builds.
