### PR TITLE
Fix broken build (simpledb polyfill)

### DIFF
--- a/app/scripts/third_party/simpledb_polyfill.js
+++ b/app/scripts/third_party/simpledb_polyfill.js
@@ -118,7 +118,7 @@
         var tx = that._db.transaction(STORE, 'readwrite');
         var store = tx.objectStore(STORE);
         var results = [];
-        for (var key of keys) {
+        for (var i = 0, key; key = keys[i]; i++) {
           store.get(key).onsuccess(function(result) {
             results.push(result);
           });
@@ -132,7 +132,7 @@
       return new Promise(function(resolve, reject) {
         var tx = that._db.transaction(STORE, 'readwrite');
         var store = tx.objectStore(STORE);
-        for (var entry of entries) {
+        for (var i = 0, entry; entry = entries[i]; i++) {
           store.put(entry.value, entry.key);
         }
         tx.oncomplete = function() { resolve(undefined); };
@@ -144,7 +144,7 @@
       return new Promise(function(resolve, reject) {
         var tx = that._db.transaction(STORE, 'readwrite');
         var store = tx.objectStore(STORE);
-        for (var key of keys)
+        for (var i = 0, key; key = keys[i]; i++)
         store.delete(key);
         tx.oncomplete = function() { resolve(undefined); };
         tx.onabort = function() { reject(tx.error); };


### PR DESCRIPTION
Simpledb polyfill broke gulp builds by using ES6 `for..of` loop.
Looks like `uglify-js` [doesn't support](https://github.com/mishoo/UglifyJS2/issues/448) this syntax.
