### PR TITLE
Removed overflow-* properties from the body

### DIFF
--- a/app/styles/base/_reset.scss
+++ b/app/styles/base/_reset.scss
@@ -24,11 +24,6 @@ html, body {
   -webkit-tap-highlight-color: transparent;
 }
 
-body {
-  overflow-x: auto;
-  overflow-y: scroll;
-}
-
 * {
   box-sizing: border-box;
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,9 +45,7 @@ gulp.task('clean', function(cleanCallback) {
 });
 
 gulp.task('sass', function() {
-  return gulp.src([
-      APP_DIR + '/{styles,elements}/**/*.scss'
-    ])
+  return gulp.src([APP_DIR + '/{styles,elements}/**/*.scss'])
     .pipe($.sass({outputStyle: 'compressed'}))
     .pipe($.changed(APP_DIR + '/{styles,elements}', {extension: '.scss'}))
     .pipe($.autoprefixer([
@@ -333,7 +331,7 @@ gulp.task('setup', function(cb) {
 // or rebuid stuff.
 function watch() {
   gulp.watch([APP_DIR + '/**/*.html'], reload);
-  gulp.watch([APP_DIR + '/styles/**/*.{scss,css}'], ['styles', reload]);
+  gulp.watch([APP_DIR + '/styles/**/*.{scss,css}'], ['sass', reload]);
   gulp.watch([APP_DIR + '/scripts/**/*.js'], ['jshint']);
   gulp.watch([APP_DIR + '/images/**/*'], reload);
   gulp.watch([APP_DIR + '/bower.json'], ['bower']);


### PR DESCRIPTION
R: @ebidel 

`overflow-y: scroll` on `body` was causing that annoying second scrollbar:

![image](https://cloud.githubusercontent.com/assets/1749548/5573068/be7b2b60-8f74-11e4-8965-daf7f6926cd2.png)

I'm assuming it and `overflow-x: auto` won't be missed.

Also, corrected a reference in `gulpfile.js` to the "styles" task. It should be "sass".
