### PR TITLE
Call IOWA.Analytics.trackError() from window.onerror

### DIFF
--- a/app/scripts/helper/analytics.js
+++ b/app/scripts/helper/analytics.js
@@ -30,7 +30,10 @@ IOWA.Analytics = (function(exports) {
     this.loadTrackingCode();
 
     var opts = {siteSpeedSampleRate: 50}; // 50% of users.
-    if (!exports.DEV) {
+    if (exports.DEV) {
+      // See https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#localhost
+      opts.cookieDomain = 'none';
+    } else {
       opts.cookiePath = '/events/io2015';
     }
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -33,6 +33,7 @@
     try {
       IOWA.Analytics.trackError(file + ':' + lineNumber, message);
     } catch (e) {
+      // no-op
     }
   };
 


### PR DESCRIPTION
@ebidel @brendankenny & co.:

This closes #77 with the addition of a `IOWA.Analytics.trackError()` method, which is hooked up into the `window.onerror` handler.

It also only sets the `cookiePath` when initializing GA if we're not on the DEV environment, since setting it when running from localhost/ prevents any GA pings from firing.
