### PR TITLE
Use an implicit relative path for sw.js and limit the scope to './'.

### DIFF
--- a/app/scripts/bootstrap.js
+++ b/app/scripts/bootstrap.js
@@ -17,8 +17,8 @@
 if ('serviceWorker' in navigator) {
 
   // TODO: change scope accordingly to the production address.
-  navigator.serviceWorker.register('/sw.js', {
-    scope: '/'
+  navigator.serviceWorker.register('sw.js', {
+    scope: './'
   }).then(function(registration) {
 
     var newServiceWorkerAvailableMessage =


### PR DESCRIPTION
@ebidel 

Should address those errors you were seeing when accessing the site from `/app/`.
