### PR TITLE
Fixes #122.

### DIFF
--- a/app/styles/components/_footer.scss
+++ b/app/styles/components/_footer.scss
@@ -60,6 +60,8 @@ footer {
   }
   .footer-content {
     nav {
+      flex-direction: row !important;
+      flex: 1;
       width: 550px;
     }
   }

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -191,32 +191,31 @@ limitations under the License.
         <template id="template-content-container" ref="" bind>{% template "content" .%}</template>
       </main>
 
-      <footer layout horizontal>
-        <img src="images/google-logo.svg" self-end>
-        <div class="footer-content" flex layout vertical end>
-          <a href="#navbar" class="footer-backtotop">Back to the top <core-icon icon="hardware:keyboard-arrow-up"></core-icon></a>
-          <nav layout horizontal vertical?="{{isPhoneSize}}" end justified flex?="{{isDesktopSize || isTabletSize}}">
-            <span><a href="#">FAQ</a></span>
-            <span><a href="https://www.google.com/events/io">I/O 2014</a></span>
-            <paper-dropdown-menu label="Google Developers">
-              <paper-dropdown valign="bottom" class="dropdown">
-                <paper-item><a href="https://developers.google.com">developers.google.com</a></paper-item>
-                <paper-item><a href="https://plus.google.com/+GoogleDevelopers">+googledevelopers</a></paper-item>
-                <paper-item><a href="http://googledevelopers.blogspot.com/">Blog</a></paper-item>
-              </paper-dropdown>
-            </paper-dropdown-menu>
-
-            <span><a href="#">I/O Community</a></span>
-            <span><a href="https://www.google.com/intl/en/policies/terms/">Privacy</a> &amp; <a href="https://www.google.com/intl/en/policies/terms/">Terms</a></span>
-          <span>
-            <a href="https://plus.google.com/+GoogleDevelopers"><core-icon icon="social:post-gplus"></core-icon></a>
-            <a href="https://twitter.com/googledevs"><core-icon icon="social:post-twitter"></core-icon></a>
-          </span>
-          </nav>
-        </div>
-      </footer>
-
     </template>
+
+    <footer layout horizontal>
+      <img src="images/google-logo.svg" self-end>
+      <div class="footer-content" flex layout vertical end>
+        <a href="#navbar" class="footer-backtotop">Back to the top <core-icon icon="hardware:keyboard-arrow-up"></core-icon></a>
+        <nav layout vertical end justified>
+          <span><a href="faq">FAQ</a></span>
+          <span><a href="https://www.google.com/events/io">I/O 2014</a></span>
+          <paper-dropdown-menu label="Google Developers">
+            <paper-dropdown valign="bottom" class="dropdown">
+              <paper-item><a href="https://developers.google.com">developers.google.com</a></paper-item>
+              <paper-item><a href="https://plus.google.com/+GoogleDevelopers">+googledevelopers</a></paper-item>
+              <paper-item><a href="http://googledevelopers.blogspot.com/">Blog</a></paper-item>
+            </paper-dropdown>
+          </paper-dropdown-menu>
+          <span><a href="offsite">I/O Community</a></span>
+          <span><a href="https://www.google.com/intl/en/policies/terms/">Privacy</a> &amp; <a href="https://www.google.com/intl/en/policies/terms/">Terms</a></span>
+        <span>
+          <a href="https://plus.google.com/+GoogleDevelopers"><core-icon icon="social:post-gplus"></core-icon></a>
+          <a href="https://twitter.com/googledevs"><core-icon icon="social:post-twitter"></core-icon></a>
+        </span>
+        </nav>
+      </div>
+    </footer>
 
   </div>
 </core-drawer-panel>


### PR DESCRIPTION
R: @jeffposnick @brendankenny, all

Takes the footer out of the auto binding template and uses raw media queries instead of bindings. The issue was the auto-binding template and the way the overlay sets itself up.
