### PR TITLE
Replace window.DEV with configurable window.ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ To run a backend server you'll need:
 Run `gulp serve` to start a standalone backend, while still enjoying live-reload.
 You'll need Go for that.
 
+Normally the app is running in "dev" environment but you can change that by
+modifying `APP_ENV` environment variable:
+
+  `APP_ENV=prod gulp serve`
+
 You can also use GAE dev appserver by running `gulp serve:gae`. This is closer to what
 we're using in our webapp environment but a bit slower on startup.
 You'll need `gcloud` tool and `app` component to do this.
+
+To change the app environment when using GAE SDK, modify the app version
+to end either with "-stage" or "-prod" in `app.yaml`.
 
 Both gulp tasks accept optional `--no-watch` argument in case you need to disable
 file watchers and live reload.
@@ -53,6 +61,9 @@ To deploy complete application on App Engine:
 
 1. Run `gulp` which will build both frontend and backend in `dist` directory.
 2. Run `gcloud preview app deploy [--version <v>] dist/backend`.
+
+The version also determines the app environment: dev, stage or prod.
+It is matched against "-stage" and "-prod" suffixes. Defaults to dev if none matched.
 
 ## Backend
 

--- a/app/scripts/helper/analytics.js
+++ b/app/scripts/helper/analytics.js
@@ -18,7 +18,7 @@ IOWA.Analytics = (function(exports) {
 
   "use strict";
 
-  var GA_TRACKING_CODE = exports.DEV ? 'UA-58124138-2' : 'UA-58124138-1';
+  var GA_TRACKING_CODE = exports.ENV == 'dev' ? 'UA-58124138-2' : 'UA-58124138-1';
 
   /**
    * Analytics for the I/O Web App.
@@ -30,7 +30,7 @@ IOWA.Analytics = (function(exports) {
     this.loadTrackingCode();
 
     var opts = {siteSpeedSampleRate: 50}; // 50% of users.
-    if (exports.DEV) {
+    if (exports.ENV == 'dev') {
       // See https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#localhost
       opts.cookieDomain = 'none';
     } else {
@@ -148,7 +148,7 @@ IOWA.Analytics = (function(exports) {
     document.addEventListener(eventName, function() {
       var now = exports.performance.now();
 
-      if (exports.DEV) {
+      if (exports.ENV == 'dev') {
         console.info(eventName, '@', now);
       }
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -20,7 +20,7 @@
   exports.IOWA = exports.IOWA || {};
 
   // TODO(ericbidelman): add i18n support.
-  // if (exports.DEV) {
+  // if (exports.ENV == 'dev') {
   //   // Polyfill needs I18nMsg to exist before setting the lang. Timing is fine for native.
   //   // Set locale for entire site (e.g. i18n-msg elements).
   //   document.addEventListener('HTMLImportsLoaded', function() {

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -224,7 +224,7 @@ limitations under the License.
 
 <!-- TODO: Move to automatic concatenation via codekit-gulp -->
 <script>
-  window.DEV = true; // Remove for prod.
+  window.ENV = {% .Env %};
 </script>
 <script src="scripts/main.js"></script>
 <script src="scripts/helper/history.js"></script>

--- a/backend/handler.go
+++ b/backend/handler.go
@@ -23,7 +23,7 @@ func serveTemplate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html;charset=utf-8")
-	err := renderTemplate(w, tplname, wantsPartial)
+	err := renderTemplate(w, env(r), tplname, wantsPartial)
 
 	if err != nil {
 		log.Printf("renderTemplate: %v", err)

--- a/backend/server.go
+++ b/backend/server.go
@@ -18,12 +18,18 @@ import (
 var (
 	rootDir    string
 	listenAddr string
+	appEnv     string
 )
 
 // main is the entry point of the standalone server.
 func main() {
+	appEnv = os.Getenv("APP_ENV")
+	if appEnv == "" {
+		appEnv = "dev"
+	}
 	flag.StringVar(&rootDir, "d", "app", "app root dir")
 	flag.StringVar(&listenAddr, "listen", "127.0.0.1:8080", "address to listen on")
+	flag.StringVar(&appEnv, "env", appEnv, "app environment: dev, stage or prod")
 	flag.Parse()
 
 	http.HandleFunc("/", catchAllHandler)
@@ -52,4 +58,13 @@ func catchAllHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.ServeFile(w, r, p)
+}
+
+// env returns current app environment: "dev", "stage" or "prod".
+// The environment is determined by either APP_ENV process environment
+// or '-env' command line flag.
+func env(_ *http.Request) string {
+	// Request arg is accepted to make the func compatible
+	// with GAE version.
+	return appEnv
 }

--- a/backend/server_gae.go
+++ b/backend/server_gae.go
@@ -5,11 +5,38 @@
 
 package main
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+
+	"appengine"
+)
 
 // rootDir is relative to basedir of app.yaml is (app root)
 var rootDir = "app"
 
 func init() {
 	http.HandleFunc("/", serveTemplate)
+}
+
+// env returns current app environment: "dev", "stage" or "prod".
+// The environment is determined by the app version which request r
+// was routed to:
+//   "-prod" suffix results into "prod" env
+//   "-stage" suffix results into "stage"
+//   default is "dev"
+// App version is speicified in app.yaml.
+func env(r *http.Request) string {
+	c := appengine.NewContext(r)
+	v := appengine.VersionID(c)
+	if i := strings.Index(v, "."); i > 0 {
+		v = v[:i]
+	}
+	switch {
+	case strings.HasSuffix(v, "-prod"):
+		return "prod"
+	case strings.HasSuffix(v, "-stage"):
+		return "stage"
+	}
+	return "dev"
 }

--- a/backend/template.go
+++ b/backend/template.go
@@ -22,7 +22,8 @@ var tmplFunc = template.FuncMap{
 
 // renderTemplate executes a template found in name.html file
 // using either layout_full.html or layout_partial.html as the root template.
-func renderTemplate(w io.Writer, name string, partial bool) error {
+// env is the app current environment: "dev", "stage" or "prod".
+func renderTemplate(w io.Writer, env, name string, partial bool) error {
 	var layout string
 	if partial {
 		layout = "layout_partial.html"
@@ -43,10 +44,12 @@ func renderTemplate(w io.Writer, name string, partial bool) error {
 		Title string
 		Slug  string
 		Meta  meta
+		Env   string
 	}{
 		Title: pageTitle(m),
 		Slug:  name,
 		Meta:  m,
+		Env:   env,
 	}
 	return t.Execute(w, data)
 }

--- a/backend/template_test.go
+++ b/backend/template_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"html/template"
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -13,15 +14,27 @@ func init() {
 
 func TestRenderFull(t *testing.T) {
 	var b bytes.Buffer
-	if err := renderTemplate(&b, "about", false); err != nil {
-		t.Fatalf("render(about): %v", err)
+	if err := renderTemplate(&b, "dev", "about", false); err != nil {
+		t.Fatalf("renderTemplate(dev, about, false): %v", err)
 	}
 }
 
 func TestRenderPartial(t *testing.T) {
 	var b bytes.Buffer
-	if err := renderTemplate(&b, "about", true); err != nil {
-		t.Fatalf("render(about): %v", err)
+	if err := renderTemplate(&b, "dev", "about", true); err != nil {
+		t.Fatalf("renderTemplate(dev, about, true): %v", err)
+	}
+}
+
+func TestRenderEnv(t *testing.T) {
+	var b bytes.Buffer
+	if err := renderTemplate(&b, "prod", "home", false); err != nil {
+		t.Fatalf("renderTemplate(prod, home, false): %v", err)
+	}
+
+	r := `window\.ENV\s+=\s+"prod";`
+	if matched, err := regexp.Match(r, b.Bytes()); !matched || err != nil {
+		t.Errorf("didn't match %s to: %s (%v)", r, b.String(), err)
 	}
 }
 


### PR DESCRIPTION
Here's one implementation for #95.
@jeffposnick is this something close to what you wanted it to be?

Let me know what you guys think. We can always go back to just populating `window.DEV` boolean.
