### PR TITLE
Make 'gcloud deploy' happy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Normally the app is running in "dev" environment but you can change that by
 modifying `APP_ENV` environment variable:
 
   ```
+  # run in dev mode, default:
+  gulp serve
   # set app environment to production:
   APP_ENV=prod gulp serve
   # or run as if we were in staging:
@@ -49,8 +51,16 @@ You can also use GAE dev appserver by running `gulp serve:gae`. This is closer t
 we're using in our webapp environment but a bit slower on startup.
 You'll need `gcloud` tool and `app` component to do this.
 
-To change the app environment when using GAE SDK, modify the app version
-to end either with "-stage" or "-prod" in `app.yaml`.
+To change the app environment when using GAE SDK, modify the same env var:
+
+  ```
+  # run in dev mode, default:
+  gulp serve:gae
+  # set app environment to production:
+  APP_ENV=prod gulp serve:gae
+  # or run as if we were in staging:
+  APP_ENV=stage gulp serve:gae
+  ```
 
 Both gulp tasks accept optional `--no-watch` argument in case you need to disable
 file watchers and live reload.
@@ -59,17 +69,28 @@ file watchers and live reload.
 
 Run `gulp`. This will create `dist` directory with both front-end and backend parts, ready for deploy.
 
+**Note**: Build won't succeed if either `gulp jshint` or `gulp jscs` reports errors.
+
 You can also serve the build from `dist` by running `gulp serve:dist`,
 and navigating to http://localhost:8080.
 
-**Note**: Build won't succeed if either `gulp jshint` or `gulp jscs` reports errors.
+`serve:dist` runs the app in `prod` mode by default. You can change that
+by modifying the same env var as with other `serve` tasks. For instance:
+
+  ```
+  APP_ENV=stage gulp serve:dist
+  ```
 
 ### Deploying
 
 To deploy complete application on App Engine:
 
 1. Run `gulp` which will build both frontend and backend in `dist` directory.
-2. Run `gcloud preview app deploy dist/backend [--version <v>]`.
+2. Run `gcloud preview app deploy dist/backend --version <v>`.
+
+The app will be deployed to the project configured in `gcloud` tool.
+To check which project you're deploying to, run `gcloud config list`
+and look for `project = ...` line.
 
 The version also determines the app environment: dev, stage or prod.
 It is matched against "-stage" and "-prod" suffixes. Defaults to dev if none matched.

--- a/backend/app.yaml
+++ b/backend/app.yaml
@@ -1,6 +1,3 @@
-application: io-webapp-staging
-version: 1
-
 runtime: go
 api_version: go1
 threadsafe: yes

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,7 @@ var glob = require('glob');
 
 var APP_DIR = 'app';
 var BACKEND_DIR = 'backend';
+var BACKEND_APP_YAML = BACKEND_DIR + '/app.yaml';
 
 var STATIC_VERSION = 1; // Cache busting static assets.
 var VERSION = argv.build || STATIC_VERSION;
@@ -235,14 +236,14 @@ gulp.task('pagespeed', pagespeed.bind(null, {
 // Start a standalone server (no GAE SDK needed) serving both front-end and backend,
 // watch for file changes and live-reload when needed.
 // If you don't want file watchers and live-reload, use '--no-watch' option.
-gulp.task('serve', ['sass', 'backend'], function(cb) {
+gulp.task('serve', ['sass', 'backend'], function() {
   var noWatch = argv.watch === false;
   var serverAddr = 'localhost:' + (noWatch ? '3000' : '8080');
   var startArgs = ['-d', APP_DIR, '-listen', serverAddr];
   var start = spawn.bind(null, BACKEND_DIR + '/bin/server', startArgs, {stdio: 'inherit'});
 
   if (noWatch) {
-    start().on('close', cb);
+    start();
     serverAddr = 'http://' + serverAddr;
     console.log('The site should now be available at: ' + serverAddr);
     opn(serverAddr);
@@ -264,49 +265,51 @@ gulp.task('serve', ['sass', 'backend'], function(cb) {
   });
 
   run();
-  browserSync({notify: false, proxy: '127.0.0.1:8080'});
+  browserSync({notify: false, proxy: serverAddr});
 
   watch();
   gulp.watch([BACKEND_DIR + '/**/*.go'], function() {
     console.log('Building backend');
     buildBackend(restart);
   });
-
-  cb();
 });
 
 // The same as 'serve' task but using GAE dev appserver.
 // If you don't want file watchers and live-reload, use '--no-watch' option.
-gulp.task('serve:gae', ['sass'], function(cb) {
+gulp.task('serve:gae', ['sass'], function() {
+  var appEnv = process.env.APP_ENV || 'dev';
+  var restoreAppYaml = changeBackendGaeAppVersion('v-' + appEnv);
+
   var noWatch = argv.watch === false;
   var serverAddr = 'localhost:' + (noWatch ? '3000' : '8080');
   var args = ['preview', 'app', 'run', BACKEND_DIR, '--host', serverAddr];
 
   var backend = spawn('gcloud', args, {stdio: 'inherit'});
   if (noWatch) {
-    backend.on('close', cb);
+    process.on('exit', restoreAppYaml);
     serverAddr = 'http://' + serverAddr;
     console.log('The site should now be available at: ' + serverAddr);
-    opn(serverAddr);
+    // give GAE server some time to start
+    setTimeout(opn.bind(null, serverAddr, null, null), 2000);
     return;
   }
 
-  browserSync.emitter.on('service:exit', backend.kill.bind(backend, 'SIGTERM'));
-
-  // give GAE serve some time to start
-  var bs = browserSync.bind(null, {notify: false, proxy: '127.0.0.1:8080'});
-  setTimeout(bs, 2000);
-
+  browserSync.emitter.on('service:exit', restoreAppYaml);
+  // give GAE server some time to start
+  setTimeout(browserSync.bind(null, {notify: false, proxy: serverAddr}), 2000);
   watch();
-  cb();
 });
 
 // Serve build with GAE dev appserver. This is how it would look in production.
 // There are no file watchers.
-gulp.task('serve:dist', ['default'], function(cb) {
+gulp.task('serve:dist', ['default'], function() {
+  var distAppYamlPath = DIST_STATIC_DIR + '/' + BACKEND_APP_YAML;
+  var appEnv = process.env.APP_ENV || 'prod';
+  var restoreAppYaml = changeBackendGaeAppVersion('v-' + appEnv, distAppYamlPath);
+  process.on('exit', restoreAppYaml);
+
   var args = ['preview', 'app', 'run', DIST_STATIC_DIR + '/' + BACKEND_DIR];
-  var proc = spawn('gcloud', args, {stdio: 'inherit'});
-  proc.on('close', cb);
+  spawn('gcloud', args, {stdio: 'inherit'});
 });
 
 gulp.task('vulcanize', ['vulcanize-elements']);
@@ -369,6 +372,16 @@ function buildBackend(cb) {
 function testBackend() {
   var args = ['test', '-v'];
   return spawn('go', args, {cwd: BACKEND_DIR, stdio: 'inherit'});
+}
+
+// Replace current app.yaml with the modified 'version' property.
+// appYamlPath arg is optional and defaults to BACKEND_APP_YAML.
+// Returns a function that restores original app.yaml content.
+function changeBackendGaeAppVersion(version, appYamlPath) {
+  appYamlPath = appYamlPath || BACKEND_APP_YAML;
+  var appYaml = fs.readFileSync(appYamlPath);
+  fs.writeFileSync(appYamlPath, 'version: ' + version + '\n' + appYaml);
+  return fs.writeFileSync.bind(fs, appYamlPath, appYaml, null);
 }
 
 // Load custom tasks from the `tasks` directory

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-vulcanize": "^3.1.0",
     "jshint-stylish": "^0.4.0",
     "node-dir": "0.1.6",
-    "opn": "^1.0.0",
+    "opn": "^1.0.1",
     "psi": "^0.1.2",
     "require-dir": "^0.1.0",
     "run-sequence": "^0.3.6",
@@ -46,7 +46,6 @@
     "sw-precache": "git://github.com/jeffposnick/sw-precache#e2474c026827f4cfc1ae8c49b840f02db5f58cd8",
     "through2": "0.6.3",
     "vinyl-map": "1.0.1",
-    "yargs": "1.3.3",
-    "opn": "^1.0.1"
+    "yargs": "1.3.3"
   }
 }


### PR DESCRIPTION
by removing `application` and `version` from `app.yaml`.

`gcloud preview app deploy --version v` will fail if either gcloud project doesn't match application field or the app version specified with `--version` arg does not match the one in `app.yaml`.

This PR also unifies dev/stage/prod mode setting for all `serve`, `serve:gae` and `serve:dist` tasks.

The real reason is, this PR will make it easy to implement #149 (deploy on green).
