### PR TITLE
Use local node_modules version of webpack scripts.

### DIFF
--- a/experiment/bin/build
+++ b/experiment/bin/build
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 npm install
-STATIC_BASE=$1 webpack -p
+STATIC_BASE=$1 node_modules/webpack/bin/webpack.js -p

--- a/experiment/bin/watch
+++ b/experiment/bin/watch
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-npm install && webpack-dev-server -d --progress --colors --content-base public
+npm install && node_modules/webpack-dev-server/bin/webpack-dev-server.js -d --progress --colors --content-base public

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -32,6 +32,7 @@
     "style-loader": "^0.8.2",
     "toxiclibsjs": "^0.2.7",
     "url-loader": "^0.5.5",
-    "webpack": "^1.4.15"
+    "webpack": "^1.4.15",
+    "webpack-dev-server": "^1.7.0"
   }
 }


### PR DESCRIPTION
@ebidel 

Should work around the need to `npm install -g` the `webpack` dependencies in order to build/serve the experiment.
