### PR TITLE
Removes js-signals from bower.json and gulpfile.js

### DIFF
--- a/app/bower.json
+++ b/app/bower.json
@@ -30,7 +30,6 @@
     "google-apis": "GoogleWebComponents/google-apis#^0.4.3",
     "google-youtube": "GoogleWebComponents/google-youtube#^1.0.1",
     "i18n-msg": "ebidel/i18n-msg#^0.0.1",
-    "js-signals": "millermedeiros/js-signals#^1.0.0",
     "paper-button": "Polymer/paper-button#552f5bbc1796207ebff82171316d639c0d5b7afd",
     "paper-dropdown": "Polymer/paper-dropdown#^0.5.2",
     "paper-dropdown-menu": "Polymer/paper-dropdown-menu#^0.5.2",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -161,7 +161,6 @@ gulp.task('copy-assets', ['copy-bower-dependencies'], function() {
 // reference that cruft from anywhere, it presumably shouldn't incur overhead.
 gulp.task('copy-bower-dependencies', function() {
   var bowerPackagesToCopy = [
-    'js-signals',
     'shed',
     'webcomponentsjs'
   ];


### PR DESCRIPTION
@ebidel @paullewis 
They were leftover from the CDS and aren't being used.
