### PR TITLE
Email addresses and domain-wide whitelisting

### DIFF
--- a/backend/whitelist
+++ b/backend/whitelist
@@ -1,0 +1,11 @@
+@google.com
+plusqa@instrument.com
+amie@instrument.com
+phong@instrument.com
+thomas@instrument.com
+alex@instrument.com
+evan.gutt@instrument.com
+dan@instrument.com
+chip@instrument.com
+bethany@instrument.com
+laurel@instrument.com


### PR DESCRIPTION
Once this is merged, this page will appear instead while visiting `localhost:3000` for the first time:
![screen shot 2015-01-16 at 3 25 15 pm](https://cloud.githubusercontent.com/assets/25405/5778590/56bcbfc4-9d94-11e4-9e48-15d8577b8762.png)

Just replace `example.com` with `google.com` and hit Login button.

Closes #239 
