### PR TITLE
Re-enable SW precaching in dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -443,7 +443,7 @@ gulp.task('generate-service-worker-dist', function(callback) {
   var distDir = DIST_STATIC_DIR + '/' + APP_DIR;
   del([distDir + '/service-worker.js']);
 
-  generateServiceWorker(distDir, false, function(error, serviceWorkerFileContents) {
+  generateServiceWorker(distDir, true, function(error, serviceWorkerFileContents) {
     if (error) {
       return callback(error);
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "require-dir": "^0.1.0",
     "run-sequence": "^0.3.6",
     "sprintf-js": "1.0.2",
-    "sw-precache": "git://github.com/jeffposnick/sw-precache#7b17a749495dfe749aaafbc05ecfe66ae8ae0373",
+    "sw-precache": "git://github.com/jeffposnick/sw-precache#77b1c3782a703fc6ccf2f908a20a94087498cd2a",
     "through2": "0.6.3",
     "vinyl-map": "1.0.1",
     "yargs": "1.3.3"


### PR DESCRIPTION
This fixes #249 

It pulls in the latest version of `sw-precache`, which will use `Request` objects with `{credentials: 'same-origin'}` set. This causes the precaching requests to include cookies, and makes the dev App Engine server happy. So we can serve from the SW cache in dist! :smile: 

(The issue in my previous testing was due to modifications I made to the SW cache polyfill not being picked up, because `shed` was also including a copy of the polyfill, and `shed`'s copy took precedence...)
