### PR TITLE
SW-related updates

### DIFF
--- a/app/scripts/bootstrap.js
+++ b/app/scripts/bootstrap.js
@@ -20,6 +20,10 @@ if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('service-worker.js', {
     scope: './'
   }).then(function(registration) {
+    // Check to see if there's an updated version of service-worker.js with new files to cache:
+    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-update-method
+    registration.update();
+
     registration.onupdatefound = function() {
       // updatefound is also fired the very first time the SW is installed, and there's no need to
       // prompt for a reload at that point. So check here to see if the page is already controlled,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "require-dir": "^0.1.0",
     "run-sequence": "^0.3.6",
     "sprintf-js": "1.0.2",
-    "sw-precache": "git://github.com/jeffposnick/sw-precache#77b1c3782a703fc6ccf2f908a20a94087498cd2a",
+    "sw-precache": "^1.0.0",
     "through2": "0.6.3",
     "vinyl-map": "1.0.1",
     "yargs": "1.3.3"


### PR DESCRIPTION
@ebidel & co.:

Explicitly call registration.update() to ensure each visit triggers a check for new content.
Pick up the published 1.0.0 release of `sw-precache`.
