### PR TITLE
networkFirst cache strategy for /experiment/

### DIFF
--- a/app/scripts/shed/experiment.js
+++ b/app/scripts/shed/experiment.js
@@ -1,0 +1,1 @@
+shed.router.get('/experiment/(.+)', shed.networkFirst);

--- a/gulp_scripts/generate_service_worker/index.js
+++ b/gulp_scripts/generate_service_worker/index.js
@@ -28,7 +28,8 @@ module.exports = function(rootDir, handleFetch, callback) {
       'bower_components/shed/dist/shed.js',
       'scripts/shed/offline-analytics.js',
       'scripts/shed/cache-then-network.js',
-      'scripts/shed/google-fonts.js'
+      'scripts/shed/google-fonts.js',
+      'scripts/shed/experiment.js'
     ],
     logger: util.log,
     staticFileGlobs: [


### PR DESCRIPTION
@ebidel & co.:

This closes #202 by implementing a "[network, falling back to cache](http://jakearchibald.com/2014/offline-cookbook/#network-falling-back-to-cache)" strategy for everything served under `/experiment/`.
