### PR TITLE
Add aria-labels to paper-tabs

### DIFF
--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -252,27 +252,27 @@ limitations under the License.
           <div flex><a href="./" data-ajax-link data-track-link="nav-home" data-anim-ripple><div class="io-logo"></div></a></div>
           <paper-tabs class="white {{ navBgClass }}" link noink
             valueattr="label" selected="{{selectedPage}}">
-            <paper-tab label="about">
+            <paper-tab label="about" aria-label="about">
               <a href="about" data-ajax-link data-track-link="nav-about" data-anim-ripple layout horizontal center>
                 <i18n-msg msgid="about">About</i18n-msg>
               </a>
             </paper-tab>
-            <paper-tab label="schedule">
+            <paper-tab label="schedule" aria-label="schedule">
               <a href="schedule" data-ajax-link data-track-link="nav-schedule" data-anim-ripple layout horizontal center>
                 <i18n-msg msgid="schedule">Schedule</i18n-msg>
               </a>
             </paper-tab>
-            <paper-tab label="onsite">
+            <paper-tab label="onsite" aria-label="onsite">
               <a href="onsite" data-ajax-link data-track-link="nav-onsite" data-anim-ripple layout horizontal center>
                 <i18n-msg msgid="attend-onsite">Attend onsite</i18n-msg>
               </a>
             </paper-tab>
-            <paper-tab label="offsite">
+            <paper-tab label="offsite" aria-label="offsite">
               <a href="offsite" data-ajax-link data-track-link="nav-offsite" data-anim-ripple layout horizontal center>
                 <i18n-msg msgid="attend-offsite">Attend offsite</i18n-msg>
               </a>
             </paper-tab>
-            <paper-tab label="registration">
+            <paper-tab label="registration" aria-label="registration">
               <a href="registration" data-ajax-link data-track-link="nav-registration" data-anim-ripple layout horizontal center>
                 <i18n-msg msgid="registration">Registration</i18n-msg>
               </a>


### PR DESCRIPTION
In VoiceOver, without aria-labels the tabs just read as "tab, 1 of 5". I think aria-label is the correct attr to use in this case unless @alice can recommend a better one. Since these act as links, I'm not sure if there's a preferred attr for that.
