### PR TITLE
Bump sw-precache to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",
     "sprintf-js": "1.0.2",
-    "sw-precache": "^1.1.1",
+    "sw-precache": "^1.2.0",
     "through2": "0.6.3",
     "vinyl-map": "1.0.1",
     "yargs": "1.3.3"


### PR DESCRIPTION
@ebidel & co.:

This closes #356 by using a new version of `sw-precache` which will ignore `utm_`-prefixed URL parameters.

The relevant changes are https://github.com/jeffposnick/sw-precache/commit/41f54cd8771670bd39fe6b9d784f81c0a90f459f for those who are interested.
