### PR TITLE
copy globe dependencies to dist/

### DIFF
--- a/app/bower.json
+++ b/app/bower.json
@@ -38,6 +38,7 @@
     "paper-tabs": "Polymer/paper-tabs#^0.5.4",
     "paper-toast": "Polymer/paper-toast#^0.5.4",
     "polymer": "Polymer/polymer#^0.5.4",
-    "shed": "wibblymat/shed#84fe1e0cd15fd633db9356ce597e58e7483a83da"
+    "shed": "wibblymat/shed#84fe1e0cd15fd633db9356ce597e58e7483a83da",
+    "es6-promise-2.0.1.min": "https://es6-promises.s3.amazonaws.com/es6-promise-2.0.1.min.js"
   }
 }

--- a/app/elements/webgl-globe/webgl-globe.html
+++ b/app/elements/webgl-globe/webgl-globe.html
@@ -13,6 +13,7 @@ limitations under the License.
 
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 
+<script src="../../bower_components/es6-promise-2.0.1.min/index.js"></script>
 <script src="webgl-globe-namespace.js"></script>
 <script src="matrix4x4.js"></script>
 <script src="shader-program.js"></script>
@@ -44,7 +45,7 @@ Makes a globe or whatever.
   </template>
   <script>
   (function() {
-    /* global IOWA */
+    /* global IOWA, ES6Promise */
     var ShaderProgram = IOWA.WebglGlobe.ShaderProgram;
     var Matrix4x4 = IOWA.WebglGlobe.Matrix4x4;
     var generateGeometry = IOWA.WebglGlobe.generateGeometry;
@@ -62,6 +63,9 @@ Makes a globe or whatever.
      * @type {!Matrix4x4}
      */
     var tmpTransform = new Matrix4x4();
+
+    // Trigger es6-promise
+    ES6Promise.polyfill();
 
     Polymer({
       /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,7 +106,10 @@ gulp.task('copy-assets', function() {
     APP_DIR + '/styles/**.css',
     APP_DIR + '/styles/pages/upgrade.css',
     APP_DIR + '/elements/**/images/*',
+    APP_DIR + '/elements/webgl-globe/shaders/*.{frag,vert}',
+    APP_DIR + '/elements/webgl-globe/textures/*.{jpg,png}',
     APP_DIR + '/bower_components/webcomponentsjs/webcomponents.min.js',
+    APP_DIR + '/bower_components/es6-promise-2.0.1.min/index.js',
     DIST_EXPERIMENT_DIR + '/**/*'
   ], {base: './'});
 


### PR DESCRIPTION
fixes #336 

also brings in [es6-promise](https://github.com/jakearchibald/es6-promise) to polyfill promises. Only loads in `webgl-globe`, but we could move it somewhere else if more people want to depend on it.
