### PR TITLE
Use a leading slash in shed router paths

### DIFF
--- a/app/scripts/shed/google-fonts.js
+++ b/app/scripts/shed/google-fonts.js
@@ -1,1 +1,1 @@
-shed.router.get('(.+)', shed.cacheFirst, {origin: /https?:\/\/fonts.+/});
+shed.router.get('/(.+)', shed.cacheFirst, {origin: /https?:\/\/fonts.+/});

--- a/app/scripts/shed/photo-gallery.js
+++ b/app/scripts/shed/photo-gallery.js
@@ -1,4 +1,4 @@
 // Use a cache for the Picasa API response for the Google I/O 2014 album.
 shed.router.get('/data/feed/api/user/111395306401981598462/albumid/6029456067262589905(.*)', shed.cacheFirst, {origin: /https?:\/\/picasaweb.google.com/});
 // Use a cache for the actual image files as well.
-shed.router.get('(.+)', shed.cacheFirst, {origin: /https?:\/\/lh\d*.googleusercontent.com/});
+shed.router.get('/(.+)', shed.cacheFirst, {origin: /https?:\/\/lh\d*.googleusercontent.com/});


### PR DESCRIPTION
@ebidel & co.:

It seems to want it there. I don't think the `shed.router.get()` call has an effect otherwise.
