### PR TITLE
don't specify a base dir for vulcanized files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,7 +69,7 @@ gulp.task('vulcanize-elements', ['sass'], function() {
       strip: !argv.pretty,
       csp: true,
       inline: true,
-      dest: 'app/elements/'
+      dest: APP_DIR + '/elements'
     }))
     // .pipe(i18n_replace({
     //   strict: !!argv.strict,


### PR DESCRIPTION
this fixes broken asset paths (and broken `resolvePath`). Since we end up placing elements.html manually anyway, we want paths to resolve relative to elements.html, not the working directory, so we don't want a `base` specified.

After this, asset paths go from e.g. `../../../app/bower_components/core-media-query/` to `../app/bower_components/core-media-query/`, which is correct.
