### PR TITLE
YouTube playback via autoplay attribute

### DIFF
--- a/app/scripts/helper/elements.js
+++ b/app/scripts/helper/elements.js
@@ -194,27 +194,10 @@ IOWA.Elements = (function() {
             this.fullscreenVideoActive = false; // remove from DOM.
             this.currentCard = null;
           } else {
-            var onStateChange = function(e) {
-              if (e.detail.data == 1) { // Playing state is video.state == 1.
-                thumbnail.classList.add('fadeout');
-
-                video.removeEventListener('google-youtube-state-change', onStateChange);
-              }
-            }.bind(this);
-
-            if (video.playsupported) {
-              video.play();
-              video.addEventListener('google-youtube-state-change', onStateChange);
-            } else {
-              // If video can't auto-play, fade out thumbnail and toggle navbar.
-              thumbnail.classList.add('fadeout');
-            }
-
+            thumbnail.classList.add('fadeout');
             this.toggleVideoOverlayNav(); // Drop down back button control.
           }
-
         }.bind(this);
-
       }.bind(this);
     };
 
@@ -227,11 +210,6 @@ IOWA.Elements = (function() {
         this.cardVideoTakeover(this.currentCard);
       });
     };
-
-    // TODO: https://github.com/GoogleChrome/ioweb2015/issues/382
-    // template.videoReady = function(e, detail, sender) {
-    //   this.cardVideoTakeover(this.currentCard);
-    // };
 
     template.openShareWindow = function(e, detail, sender) {
       e.preventDefault();

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -82,9 +82,9 @@
   </div>
 
   <template if="{{fullscreenVideoActive}}">
-    <div class="fullvideo__container" on-google-youtube-ready="{{videoReady}}" fit hidden>
+    <div class="fullvideo__container" fit hidden>
       <img src="images/home/recap-500@2x.jpg" class="fullvideo_thumbnail" fit>
-      <google-youtube videoid="ksvdvCDO7pA" chromeless height="100%" width="100%" fit></google-youtube>
+      <google-youtube videoid="ksvdvCDO7pA" chromeless height="100%" width="100%" fit autoplay="1"></google-youtube>
     </div>
   </template>
 

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -166,9 +166,9 @@
   </div>
 
   <template if="{{fullscreenVideoActive}}">
-    <div class="fullvideo__container" on-google-youtube-ready="{{videoReady}}" fit hidden>
+    <div class="fullvideo__container" fit hidden>
       <img src="images/home/recap-500@2x.jpg" class="fullvideo_thumbnail" fit>
-      <google-youtube videoid="ksvdvCDO7pA" chromeless height="100%" width="100%" fit></google-youtube>
+      <google-youtube videoid="ksvdvCDO7pA" chromeless height="100%" width="100%" fit autoplay="1"></google-youtube>
     </div>
   </template>
 {% end %}


### PR DESCRIPTION
@ebidel:

This fixes #382 by using the `autoplay="1"` attribute on `<google-youtube>`, which will handle the logic of automatically starting playback on browsers that support it.

Because the host page can now safely assume that playback will start as soon as it can, it doesn't need to wait for the API to be ready or add in logic to listen for the playing event.

Since the thumbnail is hidden immediately rather than when the playing event is triggered, there's a chance that a visitor might initially see a buffering player rather than a thumbnail, but I think this overall approach is cleaner and outweighs that drawback.

(Tested on both desktop and mobile browsers—the mobile experience hasn't changed.)
