### PR TITLE
Set explicit height attributes on vertical flex containers

### DIFF
--- a/app/styles/components/_footer.scss
+++ b/app/styles/components/_footer.scss
@@ -59,7 +59,7 @@ footer {
     padding-bottom: $desktopKeyline;
   }
   .footer-content {
-    height: 136px;
+    height: 136px; // Needed due to https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview
     nav {
       flex-direction: row !important;
       flex: 1;

--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -39,7 +39,7 @@
   position: relative;
   // min-height: 420px;
   min-height: 360px;
-  height: 360px;
+  height: 360px; // Needed due to https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview
   // height: 66vh; // ~2/3 viewport height
   max-height: 550px;
 


### PR DESCRIPTION
This is needed for IE11 compatibility, as detailed in https://github.com/GoogleChrome/ioweb2015/issues/416.

See https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview for a description of the bug.

@ebidel, I'm tried to choose reasonable `height` values, but I'm not as familiar with the site's layout as you are, so please :mag: carefully...
