### PR TITLE
Fixes for the #navbar > paper-tabs in IE11.

### DIFF
--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -123,7 +123,7 @@ core-drawer-panel {
     flex: none !important;
 
     a {
-      flex: inherit;
+      flex: inherit; // Needed for IE11, in order to ensure that the <a> gets assigned a width.
       font-size: 13px;
       color: inherit;
     }


### PR DESCRIPTION
@ebidel:

This addresses the issues in https://github.com/GoogleChrome/ioweb2015/issues/416 related to the navbar.

It turns off flexing for the `<paper-tab>` > `<a>`, which ensures that each `<paper-tab>` has the correct `width`.
Sets `display: inline-block` on the `<paper-tabs>` container, which gives it a `width`.

Doesn't seem to be any regressions on Chrome/Safari.
