### PR TITLE
Fixes Schedule layout issue in IE11

### DIFF
--- a/app/styles/pages/schedule.scss
+++ b/app/styles/pages/schedule.scss
@@ -68,7 +68,7 @@ core-icon[icon="schedule"] {
   }
 
   .schedule-rows {
-    width: 300px;
+    width: 300px; // Needed for IE11, to ensure the flexed children have proper widths.
   }
 }
 


### PR DESCRIPTION
@ebidel:

IE11 wasn't happy that the `<div class="schedule-roles">` didn't have an explicit width, so it didn't know how to distribute the `flex`ed children.

Assigning a `width: 300px` (responsively, when we're >= the tablet breakpoint) means that the descriptions will wrap at `200px` (`100px` gets assigned to the time), so there's a slightly different behavior for really long descriptions. This doesn't change the layout for our current placeholder descriptions, but it's something to keep in mind when we add in real descriptions—the width may need to be tweaked.

(Are we even going to have content on this page for Phase 1?)

This fixes https://github.com/GoogleChrome/ioweb2015/pull/416, since the other issues have been fixed in previous PRs.
