### PR TITLE
Don't call unregister() on the existing SW when the Toast is tapped.

### DIFF
--- a/app/scripts/bootstrap.js
+++ b/app/scripts/bootstrap.js
@@ -38,11 +38,7 @@
                 // Define a handler that will be used for the next io-toast tap, at which point it
                 // be automatically removed.
                 var tapHandler = function() {
-                  navigator.serviceWorker.getRegistration().then(function(registration) {
-                    return registration.unregister();
-                  }).then(function() {
-                    window.location.reload(true);
-                  });
+                  window.location.reload();
                 };
 
                 IOWA.Elements.Toast.showMessage('Tap here or refresh the page for the latest content.',


### PR DESCRIPTION
@ebidel & co.:

Calling `unregister()` on the existing SW isn't important anymore, since [cache cleanup](https://github.com/jeffposnick/sw-precache/blob/master/service-worker.tmpl#L46) was moved to the new SW's `install` handler.

The `unregister()` wasn't hurting anything, but it can lead to the "Caching complete. This site is ready to work offline!" Toast appearing following a refresh, when the intention is that it only appears during the first site load. So taking it out should ensure we don't get too toast-y. :bread: 
