### PR TITLE
Use autohiding controls for the YT player

### DIFF
--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -85,7 +85,9 @@
   <template if="{{fullscreenVideoActive}}">
     <div class="fullvideo__container" fit hidden>
       <img src="images/home/recap-500@2x.jpg" class="fullvideo_thumbnail" alt="Watch the I/O Recap Video" fit>
-      <google-youtube videoid="ksvdvCDO7pA" chromeless height="100%" width="100%" fit autoplay="1"></google-youtube>
+      <google-youtube videoid="ksvdvCDO7pA" height="100%" width="100%" fit autohide="1" controls="2"
+                      modestbranding="1" showinfo="0" iv_load_policy="3" rel="0" autoplay="1">
+      </google-youtube>
     </div>
   </template>
 

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -170,7 +170,9 @@
   <template if="{{fullscreenVideoActive}}">
     <div class="fullvideo__container" fit hidden>
       <img src="images/home/recap-500@2x.jpg" class="fullvideo_thumbnail" alt="Watch the I/O Recap Video" fit>
-      <google-youtube videoid="ksvdvCDO7pA" chromeless height="100%" width="100%" fit autoplay="1"></google-youtube>
+      <google-youtube videoid="ksvdvCDO7pA" height="100%" width="100%" fit autohide="1" controls="2"
+                      modestbranding="1" showinfo="0" iv_load_policy="3" rel="0" autoplay="1">
+      </google-youtube>
     </div>
   </template>
 {% end %}


### PR DESCRIPTION
@ebidel & co.:

Instead of using the chromeless `<google-youtube>` player, use a player with controls that autiohide. This should help with a11y, since it's possible to tab into the controls, and it's also possible to toggle CC using the controls.
