### PR TITLE
Dont record GA on same page nav

### DIFF
--- a/app/scripts/helper/router.js
+++ b/app/scripts/helper/router.js
@@ -139,6 +139,7 @@ IOWA.Router = (function() {
         var nextPage = parsePageNameFromAbsolutePath(el.pathname);
 
         // Prevent navigations to the same page.
+        // Note, this prevents in-page anchors. Use IOWA.Util.smoothScroll.
         if (currentPage === nextPage) {
           e.preventDefault();
           return;


### PR DESCRIPTION
R: @devnook, all
- Fixes #462
- Adds `fromHashChange` detection on page nav to support back button support on experiment - https://github.com/GoogleChrome/ioweb2015/issues/461
