### PR TITLE
Fixes #134 (again)

### DIFF
--- a/app/elements/countdown-timer/countdown-timer.html
+++ b/app/elements/countdown-timer/countdown-timer.html
@@ -217,6 +217,10 @@ Creates a countdown timer to a specific date.
         };
       },
 
+      ready: function() {
+        IOWA.CountdownTimer.Colors.Background = this.bgColor;
+      },
+
       /**
        * Resets the timer.
        *

--- a/app/styles/components/_app.scss
+++ b/app/styles/components/_app.scss
@@ -150,6 +150,7 @@ h3, h4, h5, h6 {
 }
 
 .io-countdown {
+  height: 194px;
   margin: 60px 0 360px 0;
 
   countdown-timer {
@@ -160,7 +161,6 @@ h3, h4, h5, h6 {
 
   h4 {
     @include typo-button();
-    // margin-right: 180px;
   }
 }
 

--- a/app/templates/registration.html
+++ b/app/templates/registration.html
@@ -23,34 +23,38 @@
   <div class="slide-up-delay">
     <section class="page__section page__section--countdown bg-light-grey js-experiment-instrument">
       <div class="io-countdown" layout vertical center>
-        <countdown-timer autostart
-                         bgcolor="#F5F5F5"
-                         date="Mar 10 2015 09:00:00 GMT-0700 (PDT)"
-                         dateadjustment="5" easeintime="500" waittime="300"
-                         easeouttime="400" thresholdInformation="{{thresholdInformation}}"></countdown-timer>
-        <template if="{{ thresholdInformation.thresholdDays }}">
-          <h4 class="countdown-label">
-            <i18n-msg msgid="daysuntilreg">Days until registration begins</i18n-msg>
-          </h4>
+
+        <template if="{{pageTransitionDone}}">
+          <countdown-timer autostart
+                           bgcolor="#F5F5F5"
+                           date="Mar 10 2015 09:00:00 GMT-0700 (PDT)"
+                           dateadjustment="5" easeintime="500" waittime="300"
+                           easeouttime="400" thresholdInformation="{{thresholdInformation}}"></countdown-timer>
+          <template if="{{ thresholdInformation.thresholdDays }}">
+            <h4 class="countdown-label">
+              <i18n-msg msgid="daysuntilreg">Days until registration begins</i18n-msg>
+            </h4>
+          </template>
+
+          <template if="{{ thresholdInformation.thresholdHours }}">
+            <h4 class="countdown-label">
+              <i18n-msg msgid="hoursuntilreg">Hours until registration begins</i18n-msg>
+            </h4>
+          </template>
+
+          <template if="{{ thresholdInformation.thresholdMinutes }}">
+            <h4 class="countdown-label">
+              <i18n-msg msgid="minutesuntilreg">Minutes until registration begins</i18n-msg>
+            </h4>
+          </template>
+
+          <template if="{{ thresholdInformation.thresholdSeconds }}">
+            <h4 class="countdown-label">
+              <i18n-msg msgid="secondsuntilreg">Seconds until registration begins</i18n-msg>
+            </h4>
+          </template>
         </template>
 
-        <template if="{{ thresholdInformation.thresholdHours }}">
-          <h4 class="countdown-label">
-            <i18n-msg msgid="hoursuntilreg">Hours until registration begins</i18n-msg>
-          </h4>
-        </template>
-
-        <template if="{{ thresholdInformation.thresholdMinutes }}">
-          <h4 class="countdown-label">
-            <i18n-msg msgid="minutesuntilreg">Minutes until registration begins</i18n-msg>
-          </h4>
-        </template>
-
-        <template if="{{ thresholdInformation.thresholdSeconds }}">
-          <h4 class="countdown-label">
-            <i18n-msg msgid="secondsuntilreg">Seconds until registration begins</i18n-msg>
-          </h4>
-        </template>
       </div>
     </section>
   </div>


### PR DESCRIPTION
R: all, @paullewis 

This ensures the bg color of the countdown is correct. For example, when navigating from registration page -> home -> registration, the countdown bg color was being set to the homepage's color. After a tic, it updated itself. The fix is to use `ready()` to define the color.

This also ensures the countdown paints itself after navigating back to the page. The fix was wrapping it in a conditional `<template>`.
