### PR TITLE
Set overflow-y: scroll on core-drawer-panel[main]

### DIFF
--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -99,8 +99,8 @@ core-drawer-panel {
     background-color: $color-body;
   }
   [main] {
-    overflow-x: auto;
     overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
   }
   core-toolbar .bottom {
     padding-bottom: $mobileKeyline;


### PR DESCRIPTION
@devnook @ebidel & co.:

While looking at https://github.com/GoogleChrome/ioweb2015/pull/481 with the global animation speed slowed down to 0.1x, I noticed that there are a few frames in which the header elements all shift over to the right by a few pixels, then shift back. It happens because the vertical scrollbars disappear when the `core-drawer-panel[drawer]` content is cleared mid-animation.

Also, at common desktop resolutions the current Registration page doesn't have a vertical scrollbar, so when you transition to/from a page with a vertical scrollbar to Registration, the header elements also shift.

This resolves the issue by setting `overflow-y: scroll;` on `core-drawer-panel[main]` which will unconditionally show vertical scrollbars. It means that there will be "empty" scrollbars on the Registration page, but I think that's preferable to the shifting.
