### PR TITLE
Nix registration.update()

### DIFF
--- a/app/scripts/bootstrap.js
+++ b/app/scripts/bootstrap.js
@@ -19,13 +19,6 @@
     navigator.serviceWorker.register('service-worker.js', {
       scope: './'
     }).then(function(registration) {
-      // Check to see if there's an updated version of service-worker.js with new files to cache:
-      // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-update-method
-      // Note: registration.update() is not yet widely implemented.
-      if (typeof registration.update == 'function') {
-        registration.update();
-      }
-
       registration.onupdatefound = function() {
         // The updatefound event implies that registration.installing is set; see
         // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-container-updatefound-event


### PR DESCRIPTION
@ebidel @crhym3 & co.:

As per https://github.com/GoogleChrome/ioweb2015/issues/495, the browser will obey standard cache control headers when determine whether to fetch a new copy of `service-worker.js`, so we don't have to rely on the not-widely-implemented `registration.update()`.
