### PR TITLE
sw-precache 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "selenium-standalone": "^3.2.0",
     "selenium-webdriver": "^2.44.0",
     "sprintf-js": "1.0.2",
-    "sw-precache": "^1.2.1",
+    "sw-precache": "^1.2.4",
     "through2": "0.6.3",
     "vinyl-map": "1.0.1",
     "yargs": "1.3.3"


### PR DESCRIPTION
@ebidel @crhym3 & co.:

Require `sw-precache` 1.2.4, which [includes the cache-busting URL parameter](https://github.com/jeffposnick/sw-precache/pull/13).
