### PR TITLE
add hack to fix nexus6/chrome40 border radius io-logo issue

### DIFF
--- a/app/elements/io-logo.html
+++ b/app/elements/io-logo.html
@@ -60,7 +60,7 @@ with the attribute `iologodestination`.
     <div layout horizontal style="height:100%">
       <div id="i" class="letter" flex></div>
       <div id="slash" class="letter"></div>
-      <div id="o" class="o letter" _style="max-width:[[height]]px" flex layout vertical center-center>
+      <div id="o" class="o letter" _style="max-width:[[height - 2]]px" flex layout vertical center-center>
         <div id="o2" class="o" _style="height:{{height - 20}}px;width:{{height - 20}}px" layout vertical center-center>
           <h2 id="year" aria-hidden="true">[[year]]</h2>
         </div>


### PR DESCRIPTION
fixes #534 
R: @ebidel

as discussed, for some reason this is sufficient for fixing #534 on the nexus 6 in Chrome 40. No issues in Chrome 41+.

Appears to have no ill effects elsewhere, but we should keep an eye on it.
