### PR TITLE
Fixes #526

### DIFF
--- a/app/scripts/helper/router.js
+++ b/app/scripts/helper/router.js
@@ -202,9 +202,39 @@ IOWA.Router = (function() {
       if (htmlImport && !htmlImport.import) {
         return;
       }
+
+      // FF doesn't execute the <script> inside the main content <template>
+      // (inside page partial import). Instead, the first time the partial is
+      // loaded, find any script tags in and make them runnable by appending them back to the template.
+      if (IOWA.Util.isFF()) {
+        var contentTemplate = document.querySelector(
+           '#template-' + pageName + '-content');
+        if (!contentTemplate) {
+          var containerTemplate = htmlImport.import.querySelector(
+              '[data-ajax-target-template="template-content-container"]');
+
+          var scripts = containerTemplate.content.querySelectorAll('script');
+          Array.prototype.forEach.call(scripts, function(node, i) {
+            replaceScriptTagWithRunnableScript(node);
+          });
+        }
+      }
+
       // Update content of the page.
       injectPageContent(pageName, htmlImport.import);
     });
+  }
+
+  /**
+   * Replaces in-page <script> tag in xhr'd body content with runnable script.
+   *
+   * @param {Node} node Container element to replace script content.
+   * @private
+   */
+  function replaceScriptTagWithRunnableScript(node) {
+    var script  = document.createElement('script');
+    script.text = node.innerHTML;
+    node.parentNode.replaceChild(script, node);
   }
 
   /**

--- a/app/scripts/helper/util.js
+++ b/app/scripts/helper/util.js
@@ -91,6 +91,11 @@ IOWA.Util = IOWA.Util || (function() {
     return (/Trident/gi).test(userAgent);
   }
 
+  function isFF() {
+    var userAgent = navigator.userAgent;
+    return (/Firefox/gi).test(userAgent);
+  }
+
   /**
    * Returns the static base URL of the running app.
    * https://events.google.com/io2015/about -> https://events.google.com/io2015/
@@ -116,6 +121,7 @@ IOWA.Util = IOWA.Util || (function() {
   };
 
   return {
+    isFF: isFF,
     isIE: isIE,
     isIOS: isIOS,
     isSafari: isSafari,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "blink-diff": "^1.0.7",
     "bower": "^1.3.12",
-    "browser-sync": "^1.9.1",
+    "browser-sync": "^2.0.0-rc8",
     "del": "^1.1.1",
     "dom-urls": "^0.1.1",
     "es6-promise": "^2.0.1",


### PR DESCRIPTION
R: @brendankenny , all

This is an unfortunate hack for FF. I haven't pinpointed why FF doesn't run the script the first
time the `<template>` in the page partial is added to the main page DOM, this does solve the issue.
The solution here was to find and execute the script inside the main content template manually.
Subsequent page navigations go through the normal flow.
