### PR TITLE
Use sw-precache 1.2.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "selenium-standalone": "^3.2.0",
     "selenium-webdriver": "^2.44.0",
     "sprintf-js": "1.0.2",
-    "sw-precache": "^1.2.4",
+    "sw-precache": "^1.2.5",
     "through2": "0.6.3",
     "vinyl-map": "1.0.1",
     "yargs": "1.3.3"


### PR DESCRIPTION
@ebidel & co.:

Not super-happy about swapping in some new SW logic at this late date, but while looking at the `upgrade` vs. `upgrade.html` thing as part of https://github.com/GoogleChrome/ioweb2015/pull/571 I realized that `sw-precache` was saving HTTP error responses in its cache. On the off chance that our servers temporarily start serving `5xx`s, we definitely don't want those cached.

`sw-precache` 1.2.5 includes logic to only add an response to the cache if it has a HTTP status of 200. If the status is anything else, it won't add the response and will delete the cache container. The failed precaching request won't be retried until the next time the `install` handler fires, but there should not be any impact to the online use case.

Similar logic is already in place as part of @wibblymat's `shed`, and I should have remembered this edge case sooner.

Since we no longer call the polyfilled `cache.add()` method, we can also get rid of the Cache API polyfill completely, so we end up saving a few hundred bytes in the size of the `service-worker.js` file.

The code change is in https://github.com/jeffposnick/sw-precache/commit/2e16cec3cc2797803ba839c536c72fb7330301b8 for the curious.
