### PR TITLE
Return 404 for any non-prefixed asset

### DIFF
--- a/backend/handler.go
+++ b/backend/handler.go
@@ -37,6 +37,17 @@ func handler(fn func(w http.ResponseWriter, r *http.Request)) http.Handler {
 	return h
 }
 
+// redirectHandler redirects from a /page path to /httpPrefix/page
+// It returns 404 Not Found error for any other requested asset.
+func redirectHandler(w http.ResponseWriter, r *http.Request) {
+	if ext := filepath.Ext(r.URL.Path); ext != "" {
+		code := http.StatusNotFound
+		http.Error(w, http.StatusText(code), code)
+		return
+	}
+	http.Redirect(w, r, path.Join(httpPrefix, r.URL.Path), http.StatusFound)
+}
+
 // serveTemplate responds with text/html content of the executed template
 // found under request base path.
 // 'home' template is assumed if request path ends with '/'.

--- a/backend/server.go
+++ b/backend/server.go
@@ -59,7 +59,8 @@ func main() {
 	handle("/api/social", serveSocial)
 	// setup root redirect if we're prefixed
 	if httpPrefix != "/" {
-		http.Handle("/", http.RedirectHandler(httpPrefix, http.StatusFound))
+		redirect := http.HandlerFunc(redirectHandler)
+		http.Handle("/", wrapHandler(redirect))
 	}
 
 	if err := http.ListenAndServe(listenAddr, nil); err != nil {

--- a/backend/server_gae.go
+++ b/backend/server_gae.go
@@ -44,7 +44,8 @@ func init() {
 	handle("/api/social", serveSocial)
 	// setup root redirect if we're prefixed
 	if httpPrefix != "/" {
-		http.Handle("/", http.RedirectHandler(httpPrefix, http.StatusFound))
+		redirect := http.HandlerFunc(redirectHandler)
+		http.Handle("/", wrapHandler(redirect))
 	}
 }
 


### PR DESCRIPTION
For instance, `/service-worker.js` will result in 404.
Whereas `/io2015/service-worker.js` will result in the correct content of service-worker.js file.

Non-prefixed page requests will be redirected to the prefixed path.

Fixes #585
