### PR TITLE
Register the SW earlier if there's already a controlling page

### DIFF
--- a/app/scripts/helper/elements.js
+++ b/app/scripts/helper/elements.js
@@ -21,8 +21,6 @@ IOWA.Elements = (function() {
   var updateElements = function() {
     var ioLogo = document.querySelector('io-logo');
     ioLogo.addEventListener('io-logo-animation-done', function() {
-      IOWA.ServiceWorkerRegistration.register();
-
       var optionallyLaunchExperiment = function() {
         if (window.location.search.indexOf('experiment') > -1) {
           IOWA.Elements.FAB.onFabClick();
@@ -34,6 +32,7 @@ IOWA.Elements = (function() {
         IOWA.Elements.Template.fire('page-transition-done');
 
         optionallyLaunchExperiment();
+        IOWA.ServiceWorkerRegistration.register();
       });
     });
 

--- a/app/scripts/helper/service-worker-registration.js
+++ b/app/scripts/helper/service-worker-registration.js
@@ -70,6 +70,15 @@ IOWA.ServiceWorkerRegistration = (function() {
     }
   };
 
+  // If we're already controlled by a service worker, then register as early as possible to get
+  // updates about a new service worker installation. This makes it more likely that we'll be able
+  // to detect when there's new content available and display the toast.
+  // TODO (jeffposnick): There is still a potential race condition if the browser has already
+  // detected the updated Service Worker before this code runs.
+  if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+    register();
+  }
+
   return {
     register: register
   };

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -343,11 +343,11 @@ limitations under the License.
 <script src="scripts/helper/util.js"></script>
 <script src="scripts/helper/page-animation.js"></script>
 <script src="scripts/helper/elements.js"></script>
+<script src="scripts/helper/service-worker-registration.js"></script>
 <script src="scripts/helper/history.js"></script>
 <script src="scripts/helper/router.js"></script>
 <script src="scripts/helper/request.js"></script>
 <script src="scripts/helper/picasa.js"></script>
-<script src="scripts/helper/service-worker-registration.js"></script>
 <script src="scripts/bootstrap.js"></script>
 <!-- endbuild -->
 <script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,11 +188,11 @@ gulp.task('concat-and-uglify-js', ['js'], function() {
     'helper/util.js',
     'helper/page-animation.js',
     'helper/elements.js',
+    'helper/service-worker-registration.js',
     'helper/history.js',
     'helper/router.js',
     'helper/request.js',
     'helper/picasa.js',
-    'helper/service-worker-registration.js',
     'bootstrap.js'
   ].map(function(script) {
     return APP_DIR + '/scripts/' + script;


### PR DESCRIPTION
@ebidel (CC: @slightlyoff)

There's a race condition in which the browser might detect an updated SW and start the upgrade flow prior to our `serviceWorker.register()` call, meaning we wouldn't be able to detect it and display the "Updated content is available toast."

This seems to be the quickest fix, but it's not a great long-term solution. Early on in the page's lifetime, if we detect that we're currently under control of a service worker, then we make the `serviceWorker.register()` call at that point. If we're not under control, then we defer registration until after the page animations have completed.

I think this gives us the best of both worlds, re: detecting early when we have to, while deferring initial registration (with the big payload and associated jank) until after the page animations have completed. 
