### PR TITLE
Assign a min-width to paper-dropdown.

### DIFF
--- a/app/styles/components/_footer.scss
+++ b/app/styles/components/_footer.scss
@@ -41,6 +41,10 @@ footer {
     border: none;
     font-weight: 500;
   }
+
+  paper-dropdown {
+    min-width: 200px; // Needed for IE.
+  }
 }
 
 .footer-content {


### PR DESCRIPTION
@ebidel @monicabagagem:

This addresses one of the IE11 issues at https://github.com/GoogleChrome/ioweb2015/issues/598 by assigning a `min-width` to the `<paper-dropdown>`:

![untitled4](https://cloud.githubusercontent.com/assets/1749548/6120772/fcde92da-b0a7-11e4-95cc-78fd99f80eba.png)
