### PR TITLE
Fixes #599 - Works around IE's lack of <template>

### DIFF
--- a/app/scripts/helper/router.js
+++ b/app/scripts/helper/router.js
@@ -212,13 +212,12 @@ IOWA.Router = (function() {
       // FF doesn't execute the <script> inside the main content <template>
       // (inside page partial import). Instead, the first time the partial is
       // loaded, find any script tags in and make them runnable by appending them back to the template.
-      if (IOWA.Util.isFF()) {
+      if (IOWA.Util.isFF() || IOWA.Util.isIE()) {
         var contentTemplate = document.querySelector(
            '#template-' + pageName + '-content');
         if (!contentTemplate) {
           var containerTemplate = htmlImport.import.querySelector(
               '[data-ajax-target-template="template-content-container"]');
-
           var scripts = containerTemplate.content.querySelectorAll('script');
           Array.prototype.forEach.call(scripts, function(node, i) {
             replaceScriptTagWithRunnableScript(node);
@@ -238,9 +237,17 @@ IOWA.Router = (function() {
    * @private
    */
   function replaceScriptTagWithRunnableScript(node) {
-    var script  = document.createElement('script');
-    script.text = node.innerHTML;
-    node.parentNode.replaceChild(script, node);
+    var script = document.createElement('script');
+    script.text = node.text || node.textContent || node.innerHTML;
+
+    // IE execute the script appended in the middle of the DOM. Append it to
+    // body and remove.
+    if (IOWA.Util.isIE()) {
+      document.body.appendChild(script);
+      document.body.removeChild(script);
+    } else {
+      node.parentNode.replaceChild(script, node); // FF
+    }
   }
 
   /**

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -231,7 +231,14 @@
       page.hasBeenLoaded = true;
     }
 
-    initPage();
+    // IE will be "loading" at this point. Other browsers will already be "complete".
+    if (document.readyState !== 'loading') {
+      initPage();
+    }
+
+    // Necessary for IE's lack of native <template>
+    // https://github.com/GoogleChrome/ioweb2015/issues/599
+    window._initPage = initPage;
 
   })();
   </script>

--- a/app/templates/faq.html
+++ b/app/templates/faq.html
@@ -202,7 +202,14 @@
       page.hasBeenLoaded = true;
     }
 
-    initPage();
+    // IE will be "loading" at this point. Other browsers will already be "complete".
+    if (document.readyState !== 'loading') {
+      initPage();
+    }
+
+    // Necessary for IE's lack of native <template>
+    // https://github.com/GoogleChrome/ioweb2015/issues/599
+    window._initPage = initPage;
 
   })();
   </script>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -221,7 +221,14 @@
       page.hasBeenLoaded = true;
     }
 
-    initPage();
+    // IE will be "loading" at this point. Other browsers will already be "complete".
+    if (document.readyState !== 'loading') {
+      initPage();
+    }
+
+    // Necessary for IE's lack of native <template>
+    // https://github.com/GoogleChrome/ioweb2015/issues/599
+    window._initPage = initPage;
 
   })();
   </script>

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -353,12 +353,23 @@ limitations under the License.
 <script>
 (function() {
 
+  // Necessary for IE's lack of native <template>
+  // https://github.com/GoogleChrome/ioweb2015/issues/599
+  function init() {
+    if (typeof window._initPage == 'function') {
+      window._initPage();
+      window._initPage = null;
+    }
+  }
+
   function afterImports() {
     //'import' in document.createElement('link')
     if (!IOWA.Elements.Template.pages[{% .Slug %}]) {
       IOWA.Elements.Template.pages[{% .Slug %}] = {};
     }
     IOWA.Elements.Template.pages[{% .Slug %}].title = "{% template "title" .%}";
+
+    init();
   }
 
   if (IOWA.Util.supportsHTMLImports) {

--- a/app/templates/offsite.html
+++ b/app/templates/offsite.html
@@ -194,7 +194,14 @@
       page.hasBeenLoaded = true;
     }
 
-    initPage();
+    // IE will be "loading" at this point. Other browsers will already be "complete".
+    if (document.readyState !== 'loading') {
+      initPage();
+    }
+
+    // Necessary for IE's lack of native <template>
+    // https://github.com/GoogleChrome/ioweb2015/issues/599
+    window._initPage = initPage;
 
   })();
   </script>


### PR DESCRIPTION
R: @jeffposnick, all

This was rowdy! IE is the only browser to lack `<template>` support, which means it runs the inline page `<script>` at page load. It doesn't have the inertness properties of `<template>`. In addition, the dynamic navigations were also not working in IE.  We the same FF trick to execute the page's script when navigated too.
