### PR TITLE
Use .active instead of animating translateY for overlays

### DIFF
--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -109,10 +109,6 @@
         new Animation(bottomSection, [
           {transform: 'translateY(0)', opacity: 1},
           {transform: 'translateY(100px)', opacity: 0}
-        ], animationOptions),
-        new Animation(navOverlay, [
-          {transform: 'translateY(-100%)'},
-          {transform: 'translateY(0)'}
         ], animationOptions)
       ]);
 
@@ -153,11 +149,13 @@
         // Fade out gallery and slide back in page sections at the same time.
         IOWA.PageAnimation.play(galleryAnimation);
         IOWA.PageAnimation.play(animation, opt_callback);
+        navOverlay.classList.remove('active');
       } else {
         // Slide out page sections, then fade in gallery.
         IOWA.PageAnimation.play(animation, function() {
           IOWA.PageAnimation.play(galleryAnimation, opt_callback);
         });
+        navOverlay.classList.add('active');
       }
     }
 

--- a/app/templates/offsite.html
+++ b/app/templates/offsite.html
@@ -104,10 +104,6 @@
       };
 
       var cardAnimations = new AnimationGroup([
-        new Animation(navOverlay, [
-          {transform: 'translateY(-100%)'},
-          {transform: 'translateY(0)'}
-        ], animationOptions),
         new Animation(button, [
           {opacity: 1},
           {opacity: 0}
@@ -151,11 +147,13 @@
         // Fade out gallery and slide back in page sections at the same time.
         IOWA.PageAnimation.play(videoAnimation);
         IOWA.PageAnimation.play(cardAnimations, opt_callback);
+        navOverlay.classList.remove('active');
       } else {
         // Slide out page sections, then fade in gallery.
         IOWA.PageAnimation.play(cardAnimations, function() {
           IOWA.PageAnimation.play(videoAnimation, opt_callback);
         });
+        navOverlay.classList.add('active');
       }
     }
 


### PR DESCRIPTION
@paullewis @ebidel @brendankenny & co.:

Animating the overlay toolbar using the WAAPI and `transform: translateY()` wasn't working in IE11. Using a class toggle to achieve the same transformation does work.

Since I'm only applying this class to the overlay, there are probably some more subtle card animations that aren't being run in IE11 due to their continued use of `tranform: translateY()`, but I don't want to fiddle with them since a) they're working in other browsers and b) there aren't ready-made classes that I could just apply/remove and c) we have less control over the timings when using classes.

I'll file a separate bug as a reminder to investigate what's up with `tranform: translateY()`.

This closes #598 (along with the other PRs that have already landed).
