### PR TITLE
Fix h4 and p styles in safari in loading dialog

### DIFF
--- a/app/elements/experiment-fab.html
+++ b/app/elements/experiment-fab.html
@@ -297,7 +297,7 @@ Dialog that animates in when experiment fab is clicked. If experiment is support
       }
 
       h4 {
-        color: #424242;
+        color: #424242 !important;
         font-size: 24px;
         font-weight: 400;
         margin: 0;
@@ -307,6 +307,7 @@ Dialog that animates in when experiment fab is clicked. If experiment is support
         color: #9E9E9E;
         font-size: 15px;
         font-weight: 500;
+        margin: 10px 0;
       }
 
       p a {


### PR DESCRIPTION
When shadow dom is polyfilled, some styles are leaking in to the experiment fab. This restores the correct design, as seen in Chrome, on Safari, et al.
