### PR TITLE
Fix black square in Safari recording button

### DIFF
--- a/experiment/app/views/InstrumentContainer.js
+++ b/experiment/app/views/InstrumentContainer.js
@@ -83,9 +83,9 @@ module.exports = (function() {
    */
   function getRenderer(type) {
     if (type === PIXI.CanvasRenderer) {
-      return canvasRenderers.pop();
+      return canvasRenderers.shift();
     } else {
-      return webGLRenderers.pop();
+      return webGLRenderers.shift();
     }
   }
 
@@ -95,9 +95,9 @@ module.exports = (function() {
    */
   function returnRenderer(renderer) {
     if (renderer instanceof PIXI.CanvasRenderer) {
-      canvasRenderers.push(renderer);
+      canvasRenderers.unshift(renderer);
     } else {
-      webGLRenderers.push(renderer);
+      webGLRenderers.unshift(renderer);
     }
   }
 


### PR DESCRIPTION
On Safari mobile, the parallelograms had a black square instead of a record button. This fixes that.

cc @ebidel, you guys figure out when it's safe to do deploys :)
