### PR TITLE
Add <link rel="canonical" ...> links to each page

### DIFF
--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -167,6 +167,8 @@ limitations under the License.
 
   <script src="bower_components/webcomponentsjs/webcomponents.min.js"></script>
   <link rel="import" href="elements/elements.html">
+
+  <link rel="canonical" href="{% .Slug %}">
 </head>
 <body id="page-{% .Slug %}">
 


### PR DESCRIPTION
@ebidel @devnook @crhym3 @beriberikix 

This should fix #652.

One (anticipated) side effect of this change is that the `?experiment` flavors of our URLs won't be returned in search results anymore, which I don't think is a problem. If for some reason we do want to drive traffic directly to `?experiment` URLs, then we would need to modify the logic a bit to use different canonical tags based on whether the initial navigation has `?experiment` or not.
