### PR TITLE
simplify <io-logo> animation

### DIFF
--- a/app/elements/io-logo.html
+++ b/app/elements/io-logo.html
@@ -177,7 +177,7 @@ with the attribute `iologodestination`.
 
       // This runs forward and then in reverse, so wait for half of SHOW_FOR on
       // each iteration by calculating its offset.
-      var offset = DURATION / (DURATION + this.SHOW_FOR/2);
+      var offset = DURATION / (DURATION + this.SHOW_FOR / 2);
       var animation = [
         {transform: 'scale(0)', easing: 'cubic-bezier(0,0,0.21,1)'},
         {transform: 'scale(1)', offset: offset},
@@ -186,9 +186,9 @@ with the attribute `iologodestination`.
 
       var player = this.$.o2.animate(animation, {
         delay: this.START_DELAY,
-        duration: DURATION + this.SHOW_FOR/2,
+        duration: DURATION + this.SHOW_FOR / 2,
         iterations: 2,
-        direction: 'alternate',
+        direction: 'alternate'
       });
 
       player.onfinish = this.moveLogo.bind(this);


### PR DESCRIPTION
The change to `SHOW_FOR` (increased the time) is actually a fix too, because before you were also adding `START_DELAY` in the middle of the animation being reverse.

Looking at the old/new code side-by-side, they appear to have the exact same curves/timing etc.
