### PR TITLE
Disable home button for keyboard and screen reader, make entire toolbar navigation landmark

### DIFF
--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -240,14 +240,15 @@ limitations under the License.
         <div class="masthead__ripple">
           <div class="masthead__ripple__content" id="masthead-ripple"></div>
         </div>
-        <core-toolbar id="navbar" class="{{ {'core-narrow': isPhoneSize} | tokenList }}">
+        <core-toolbar id="navbar" class="{{ {'core-narrow': isPhoneSize} | tokenList }}" role="navigation">
           <paper-icon-button icon="menu" core-drawer-toggle></paper-icon-button>
           <div flex disabled?="{{selectedPage === 'home'}}">
-            <a href="./" data-ajax-link data-track-link="nav-home" data-anim-ripple aria-label="Home">
+            <a href="./" data-ajax-link data-track-link="nav-home" data-anim-ripple aria-label="Home" aria-hidden="{{selectedPage === 'home'}}"
+            tabindex="{{selectedPage === 'home' ? -1 : 0}}">
               <div class="io-logo"></div>
             </a>
           </div>
-          <paper-tabs class="white {{ navBgClass }}" valueattr="label" selected="{{selectedPage}}" role="navigation" link noink>
+          <paper-tabs class="white {{ navBgClass }}" valueattr="label" selected="{{selectedPage}}" link noink>
             <paper-tab label="about" role="">
               <a href="about" data-ajax-link data-track-link="nav-about" data-anim-ripple layout horizontal center>
                 <i18n-msg msgid="about">About</i18n-msg>


### PR DESCRIPTION
This moves the landmark navigation role up to the entire core-toolbar, primarily because it contains a home button (sometimes). Navigating by landmarks in VoiceOver is super useful but previously the home button was being omitted from the navigation.

I've also removed the `disabled` check (it didn't seem to be doing anything useful) and added `tabindex` and `aria-hidden` rules to remove the home button from keyboards and screen readers respectively. I needed to add aria-hidden because it was still possible to navigate to the link with a tabindex=-1 using VoiceOver
