### PR TITLE
Fixup focus states for registration section

### DIFF
--- a/app/styles/base/_zindex.scss
+++ b/app/styles/base/_zindex.scss
@@ -18,7 +18,8 @@
   z-index: -1;
 }
 
-.card__container, .card {
+.card__container, .card,
+.io-countdown h4 {
   z-index: 1;
 }
 

--- a/app/styles/components/_app.scss
+++ b/app/styles/components/_app.scss
@@ -236,6 +236,10 @@ h6 {
 
     a {
       color: inherit;
+
+      &:focus {
+        outline-color: white;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #694 
- The z-index change is because the `countdown-timer` overlaps the outline area for the anchor element. Happy to change to some other approach if z-index is not preferred.
- Changed focus color to white so it doesn't blend in with background.
- Removed tabindex from h2, this element should not be focusable because it's not a control. Screen readers can still get to it

@ebidel PTAL
