### PR TITLE
Updates to notifications endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -156,7 +156,7 @@ the global notification state scoped to a user, not a specific subscriber ID.
 
 ### GET /api/v1/user/updates
 
-*Authorization: Bearer _OAUTH2_ACCESS_TOKEN_* or *Authorization: _UPDATES_TOKEN_*
+*Authorization: Bearer _OAUTH2_ACCESS_TOKEN_* or *Authorization: _SW_TOKEN_*
 
 Response body sample:
 
@@ -174,7 +174,7 @@ Response body sample:
 
 If the `Authorization` header is set to a valid OAuth 2 token, then the response will come back with
 just the `token` field populated, for use in the next request.
-If `Authorization` header is set to an update token, then the response will come back with fields
+If `Authorization` header is set to an SW token, then the response will come back with fields
 set for all the updated resources. Additionally, the `token` field will be populated, for use in
 the next request.
 


### PR DESCRIPTION
Based on some conversations with @crhym3, these are changes to the endpoint used to fetch relevant notifications for events that have taken place since a specific timestamp for a specific subscription id.

Feel free to change this around a bit (e.g., move the subscription_id out of the URL and into a parameter) or correct me if I'm making assumptions about the response that don't match with yours.

But I wanted to capture the changes that we'd need.
