### PR TITLE
Update CI and docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,15 @@
-image: crhym3/go1.4-node0.10
+image: crhym3/ci
 git:
   depth: 1
 script:
+  # workaround for cache, see https://github.com/drone/drone/issues/147
+  - mkdir -p /cache/npm /cache/bower /cache/node_modules
+  - npm config set cache /cache/npm
+  - rm -rf app/bower_components && ln -s /cache/bower app/bower_components
+  - rm -rf node_modules experiment/node_modules
+  - ln -s /cache/node_modules node_modules
+  - ln -s /cache/node_modules experiment/node_modules
+  # install dependencies
   - npm -q install
   - cd app && ../node_modules/bower/bin/bower install -q --allow-root && cd ..
   - gulp godeps
@@ -11,4 +19,6 @@ script:
   - gulp backend:test
   # deploy to appspot if this is master branch
   - util/auto-deploy
+cache:
+  - /cache
 

--- a/util/ci.dockerfile
+++ b/util/ci.dockerfile
@@ -11,12 +11,22 @@ RUN apt-get install -y \
 	bzr git mercurial \
 	--no-install-recommends
 
+ENV CLOUDSDK_CORE_DISABLE_PROMPTS=1
+ENV CLOUDSDK_PYTHON_SITEPACKAGES=1
+ADD https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz /gcloud.tar.gz
+RUN mkdir /gcloud && \
+  tar -xzf /gcloud.tar.gz --strip 1 -C /gcloud && \
+  /gcloud/install.sh && \
+  /gcloud/bin/gcloud components update app -q && \
+  rm -f /gcloud.tar.gz
+ENV PATH=/gcloud/bin:$PATH
+
+ENV NODE_VERSION 0.10.38
+ENV NPM_VERSION 2.7.3
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.31/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D
-
-ENV NODE_VERSION 0.10.35
-ENV NPM_VERSION 2.1.18
+# gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
 RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
 	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -27,14 +37,14 @@ RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x
 	&& npm install -g npm@"$NPM_VERSION" \
 	&& npm cache clear
 
-RUN npm install -g gulp bower phantomjs@1.9.13
+RUN npm install -g gulp bower
 
-ENV GOLANG_VERSION 1.4
+ENV GOLANG_VERSION 1.4.2
 
 RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
-		| tar -v -C /usr/src -xz
+		| tar -C /usr/src -xz
 
-RUN cd /usr/src/go/src && ./make.bash --no-clean 2>&1
+RUN cd /usr/src/go/src && ./make.bash --no-clean > /dev/null
 
 ENV PATH /usr/src/go/bin:$PATH
 


### PR DESCRIPTION
Also, enable caching as much as possible to speed up the builds.
Moved CI instance to us-central1-c, upgraded docker to 1.5 and drone from upstream.
Builds are now running on a bigger instance (standard-2), and a bigger SSD disk (200Gb).

`gulp jscs` fails on `helpers/page-animation.js` and `helpers/router.js`.
