### PR TITLE
Set HTTP client timeout only if supported

### DIFF
--- a/backend/server_gae.go
+++ b/backend/server_gae.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"net/http"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -25,7 +26,10 @@ func init() {
 	cache = &gaeMemcache{}
 	// apps hosted on GAE use a different HTTP transport
 	httpTransport = func(c context.Context) http.RoundTripper {
-		return &urlfetch.Transport{Context: c}
+		return &urlfetch.Transport{
+			Context:  c,
+			Deadline: 3 * time.Second,
+		}
 	}
 	// staging instance is accessed only by whitelisted people/domains
 	if isStaging() {

--- a/backend/transport.go
+++ b/backend/transport.go
@@ -15,12 +15,17 @@ var httpTransport = func(_ context.Context) http.RoundTripper {
 	return http.DefaultTransport
 }
 
-// httpClient create a new HTTP client using httpTransport().
+// httpClient create a new HTTP client using httpTransport(),
+// setting request timeout to 3 seconds if supported.
 func httpClient(c context.Context) *http.Client {
-	return &http.Client{
-		Transport: httpTransport(c),
-		Timeout:   5 * time.Second,
+	cl := &http.Client{Transport: httpTransport(c)}
+	type canceler interface {
+		CancelRequest(*http.Request)
 	}
+	if _, ok := cl.Transport.(canceler); ok {
+		cl.Timeout = 3 * time.Second
+	}
+	return cl
 }
 
 // oauth2Client creates a new HTTP client using oauth2.Transport,


### PR DESCRIPTION
Apparently GAE's [urlfetch service](https://godoc.org/google.golang.org/appengine/urlfetch) doesn't support standard [HTTP client timeout](http://golang.org/pkg/net/http/#Client), which I completely missed.

Fixes #891 
R: @ebidel 
