### PR TITLE
Remove hidden paper-buttons from taborder

### DIFF
--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -7,12 +7,12 @@
 {% end %}
 
 {% define "content" %}
-  <core-toolbar class="navbar__overlay navbar__overlay--gallery" aria-hidden="{{!photoGalleryActive}}" fit>
+  <core-toolbar class="navbar__overlay navbar__overlay--gallery" hidden?="{{!photoGalleryActive}}" fit>
     <paper-icon-button icon="arrow-back" on-tap="{{closePhotoGallery}}" aria-label="Close gallery"></paper-icon-button>
     <span flex><i18n-msg msgid="io-in-photos">I/O in Photos</i18n-msg></span>
   </core-toolbar>
 
-  <core-toolbar class="navbar__overlay navbar__overlay--video" aria-hidden="{{!fullscreenVideoActive}}" fit>
+  <core-toolbar class="navbar__overlay navbar__overlay--video" hidden?="{{!fullscreenVideoActive}}" fit>
     <paper-icon-button icon="arrow-back" on-tap="{{closeVideoCard}}" aria-label="Close video"></paper-icon-button>
     <span flex><i18n-msg msgid="watch-recap-video">Watch the 2014 I/O Recap Video</i18n-msg></span>
   </core-toolbar>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -62,7 +62,7 @@
 {% end %}
 
 {% define "content" %}
-  <core-toolbar class="navbar__overlay navbar__overlay--video" aria-hidden="{{!fullscreenVideoActive}}" fit>
+  <core-toolbar class="navbar__overlay navbar__overlay--video" hidden?="{{!fullscreenVideoActive}}" fit>
     <paper-icon-button icon="arrow-back" on-tap="{{closeVideoCard}}" aria-label="Close video"></paper-icon-button>
     <span flex><i18n-msg msgid="watch-recap-video">Watch the 2014 I/O Recap Video</i18n-msg></span>
   </core-toolbar>

--- a/app/templates/offsite.html
+++ b/app/templates/offsite.html
@@ -7,12 +7,12 @@
 {% end %}
 
 {% define "content" %}
-  <core-toolbar class="navbar__overlay navbar__overlay--video" aria-hidden="{{!fullscreenVideoActive}}" fit>
+  <core-toolbar class="navbar__overlay navbar__overlay--video" hidden?="{{!fullscreenVideoActive}}" fit>
     <paper-icon-button icon="arrow-back" on-tap="{{closeVideoSection}}" aria-label="Close video"></paper-icon-button>
     <span flex><i18n-msg msgid="ioextendedwatch">Watch the 2014 I/O Extended recap video</i18n-msg></span>
   </core-toolbar>
 
-  <core-toolbar class="navbar__overlay navbar__overlay--extended" aria-hidden="{{!fullscreenVideoActive}}" fit>
+  <core-toolbar class="navbar__overlay navbar__overlay--extended" hidden?="{{!fullscreenVideoActive}}" fit>
     <paper-icon-button icon="arrow-back" on-tap="{{closeExtendedMapSection}}" aria-label="Close extended map"></paper-icon-button>
     <span flex>2015 Extended events</span>
   </core-toolbar>

--- a/app/templates/videos.html
+++ b/app/templates/videos.html
@@ -13,7 +13,7 @@
 {% end %}
 
 {% define "content" %}
-<core-toolbar class="navbar__overlay navbar__overlay--video" aria-hidden="{{!fullscreenVideoActive}}" fit>
+<core-toolbar class="navbar__overlay navbar__overlay--video" hidden?="{{!fullscreenVideoActive}}" fit>
   <paper-icon-button icon="arrow-back" on-tap="{{closeVideoCard}}" aria-label="Close video"></paper-icon-button>
   <span flex>Videos</span>
 </core-toolbar>


### PR DESCRIPTION
Use `hidden` here to remove the element from taborder and screenreaders. Only using `aria-hidden` means you can still tab to these buttons.
