### PR TITLE
Remove agenda labels

### DIFF
--- a/app/templates/schedule.html
+++ b/app/templates/schedule.html
@@ -102,7 +102,7 @@
       class="subpage__content {{ {active: pages[selectedPage].selectedSubpage == 'agenda'} | tokenList}}">
     <section class="page__section page__section--top slide-up">
         <div class="card__container card__container--top">
-          <div class="card js-experiment-visualizer" aria-label="Agenda">
+          <div class="card js-experiment-visualizer">
             <div class="card-content">
               <h4><i18n-msg msgid="iomonth">May</i18-msg> 27, 2015</h4>
             </div>
@@ -123,7 +123,7 @@
       <div class="slide-up-delay">
         <section class="page__section">
           <div class="card__container card__container--top">
-            <div class="card js-experiment-visualizer" aria-label="Agenda">
+            <div class="card js-experiment-visualizer">
               <div class="card-content">
                 <h4><i18n-msg msgid="iomonth">May</i18-msg> 28, 2015</h4>
               </div>
@@ -155,7 +155,7 @@
         </section>
         <section class="page__section">
           <div class="card__container card__container--top">
-            <div class="card js-experiment-visualizer" aria-label="Agenda">
+            <div class="card js-experiment-visualizer">
               <div class="card-content">
                 <h4><i18n-msg msgid="iomonth">May</i18-msg> 29, 2015</h4>
               </div>
@@ -182,7 +182,7 @@
     <section id="subpage-day1" class="subpage__content {{ {active: pages[selectedPage].selectedSubpage == 'day1'} | tokenList}}">
       <section class="page__section page__section--top slide-up">
         <div class="card__container card__container--top">
-          <div class="card js-experiment-visualizer" aria-label="Agenda">
+          <div class="card js-experiment-visualizer">
             <div class="card-content">
               <h3 class="card__title">Create your schedule</h3>
               <div>Sign-in to add sessions to your personalized schedule and to view it in your time zone.</div>
@@ -201,7 +201,7 @@
         <div class="card__container sidebyside" layout horizontal>
           <div flex layout vertical>
             <section class="page__section">
-              <div class="card" aria-label="Agenda">
+              <div class="card">
                 <div class="card-content">
                   <h4>10 AM</h4>
                 </div>
@@ -241,7 +241,7 @@
                 </div>
               </div>
             </section>
-            <div class="card" aria-label="Agenda">
+            <div class="card">
               <div class="card-content">
                 <h4>10 AM</h4>
               </div>
@@ -290,7 +290,7 @@
             </div>
           </div>
           <div class="card__container" layout vertical>
-            <div class="card js-experiment-visualizer" aria-label="Agenda">
+            <div class="card js-experiment-visualizer">
               <div class="card-content">
                 <h4>Filters</h4>
               </div>


### PR DESCRIPTION
Removing these labels makes it much easier to navigate the page using a screenreader. With the labels in place, each agenda card is treated as a group, requiring special keyboard commands to "dive into" the group and navigate, and then special commands to "jump out" so you can navigate the page again. This was cited by the a11y team as frustrating. Removing the label lets you navigate the page content more easily by jumping to heading and associated content.

The Agenda label is unnecessary here as the Agenda tab is already read aloud as you're navigating into the agenda.
