### PR TITLE
Support GAE tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,6 +17,7 @@ script:
   - gulp
   # backend testing
   - gulp backend:test
+  - gulp backend:test --gae
   # deploy to appspot if this is master branch
   - util/auto-deploy
 cache:

--- a/backend/auth_test.go
+++ b/backend/auth_test.go
@@ -44,7 +44,7 @@ func TestVerifyBearerToken(t *testing.T) {
 		config.Google.Auth.Client = client
 		config.Google.VerifyURL = ts.URL
 
-		r, _ := http.NewRequest("GET", "/", nil)
+		r := newTestRequest(t, "GET", "/", nil)
 		uid, err := verifyBearerToken(newContext(r), token)
 
 		switch {
@@ -87,7 +87,7 @@ func TestVerifyIDToken(t *testing.T) {
 	defer ts.Close()
 	config.Google.CertURL = ts.URL
 
-	r, _ := http.NewRequest("GET", "/", nil)
+	r := newTestRequest(t, "GET", "/", nil)
 	c := newContext(r)
 	cache.flush(c)
 	uid, err := verifyIDToken(c, idToken)
@@ -125,8 +125,7 @@ func TestAuthUser(t *testing.T) {
 		config.Google.VerifyURL = test.verifyURL
 		config.Google.CertURL = test.certURL
 
-		r, _ := http.NewRequest("GET", "/", nil)
-		c := newContext(r)
+		c := newContext(newTestRequest(t, "GET", "/", nil))
 		cache.flush(c)
 		c, err := authUser(c, test.token)
 

--- a/backend/handler_test.go
+++ b/backend/handler_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestServeIOExtEntriesStub(t *testing.T) {
-	r, _ := http.NewRequest("GET", "/api/extended", nil)
+	r := newTestRequest(t, "GET", "/api/extended", nil)
 	w := httptest.NewRecorder()
 	serveIOExtEntries(w, r)
 
@@ -42,7 +42,7 @@ func TestServeTemplate(t *testing.T) {
 		{"/form", "form", "/root/form"},
 	}
 	for i, test := range table {
-		r, _ := http.NewRequest("GET", test.path, nil)
+		r := newTestRequest(t, "GET", test.path, nil)
 		w := httptest.NewRecorder()
 		serveTemplate(w, r)
 
@@ -76,7 +76,7 @@ func TestServeTemplateRedirect(t *testing.T) {
 		{"/one/two/", "/one/two"},
 	}
 	for i, test := range table {
-		r, _ := http.NewRequest("GET", test.start, nil)
+		r := newTestRequest(t, "GET", test.start, nil)
 		w := httptest.NewRecorder()
 		serveTemplate(w, r)
 
@@ -91,7 +91,7 @@ func TestServeTemplateRedirect(t *testing.T) {
 }
 
 func TestServeTemplate404(t *testing.T) {
-	r, _ := http.NewRequest("GET", "/a-thing-that-is-not-there", nil)
+	r := newTestRequest(t, "GET", "/a-thing-that-is-not-there", nil)
 	w := httptest.NewRecorder()
 	serveTemplate(w, r)
 	if w.Code != http.StatusNotFound {
@@ -157,7 +157,7 @@ func TestHandleAuth(t *testing.T) {
 		config.Google.TokenURL = ts.URL
 
 		p := strings.NewReader(`{"code": "` + code + `"}`)
-		r, _ := http.NewRequest("POST", "/api/v1/auth", p)
+		r := newTestRequest(t, "POST", "/api/v1/auth", p)
 		r.Header.Set("Authorization", "Bearer "+test.token)
 		w := httptest.NewRecorder()
 

--- a/backend/server_gae_test.go
+++ b/backend/server_gae_test.go
@@ -1,0 +1,72 @@
+// +build appengine
+
+package main
+
+import (
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+
+	"appengine/aetest"
+)
+
+var (
+	aetInstMu sync.Mutex
+	aetInst   = make(map[*testing.T]aetest.Instance)
+)
+
+func init() {
+	// newTestRequest returns a new *http.Request associated with an aetest.Instance
+	// of test state t.
+	newTestRequest = func(t *testing.T, method, url string, body io.Reader) *http.Request {
+		req, err := aetInstance(t).NewRequest(method, url, body)
+		if err != nil {
+			t.Fatalf("newTestRequest(%q, %q): %v", err)
+		}
+		return req
+	}
+
+	// resetTestState closes aetest.Instance associated with a test state t.
+	resetTestState = func(t *testing.T) {
+		aetInstMu.Lock()
+		defer aetInstMu.Unlock()
+		inst, ok := aetInst[t]
+		if !ok {
+			return
+		}
+		err := inst.Close()
+		if err != nil {
+			t.Logf("resetTestState: %v", err)
+		}
+		delete(aetInst, t)
+	}
+
+	// cleanupTests closes all running aetest.Instance instances.
+	cleanupTests = func() {
+		aetInstMu.Lock()
+		defer aetInstMu.Unlock()
+		for t, inst := range aetInst {
+			if err := inst.Close(); err != nil {
+				t.Logf("cleanupTests: %v", err)
+			}
+			delete(aetInst, t)
+		}
+	}
+}
+
+// aetInstance returns an aetest.Instance associated with the test state t
+// or creates a new one.
+func aetInstance(t *testing.T) aetest.Instance {
+	aetInstMu.Lock()
+	defer aetInstMu.Unlock()
+	if inst, ok := aetInst[t]; ok {
+		return inst
+	}
+	inst, err := aetest.NewInstance(nil)
+	if err != nil {
+		t.Fatalf("aetest.NewInstance: %v", err)
+	}
+	aetInst[t] = inst
+	return inst
+}

--- a/backend/template_test.go
+++ b/backend/template_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net/http"
 	"strings"
 	"testing"
 )
@@ -17,7 +16,7 @@ func TestRenderTemplate(t *testing.T) {
 		{"about", true},
 	}
 	for i, test := range table {
-		r, _ := http.NewRequest("GET", "/dummy", nil)
+		r := newTestRequest(t, "GET", "/dummy", nil)
 		c := newContext(r)
 		if _, err := renderTemplate(c, test.tmpl, test.partial, nil); err != nil {
 			t.Fatalf("%d: renderTemplate(%v, %q, %v): %v", i, c, test.tmpl, test.partial, err)
@@ -31,8 +30,8 @@ func TestRenderTemplateData(t *testing.T) {
 	config.Prefix = "/root"
 	config.Google.Auth.Client = "dummy-client-id"
 
-	req, _ := http.NewRequest("GET", "/about", nil)
-	c := newContext(req)
+	r := newTestRequest(t, "GET", "/about", nil)
+	c := newContext(r)
 
 	data := &templateData{
 		OgImage: "some-image.png",

--- a/util/ci.dockerfile
+++ b/util/ci.dockerfile
@@ -7,9 +7,10 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 RUN apt-get install -y \
-	ca-certificates curl gcc libc6-dev make \
+	ca-certificates curl python-pip gcc libc6-dev make \
 	bzr git mercurial \
 	--no-install-recommends
+RUN pip install docker-py
 
 ENV CLOUDSDK_CORE_DISABLE_PROMPTS=1
 ENV CLOUDSDK_PYTHON_SITEPACKAGES=1


### PR DESCRIPTION
This will allow to test any code that touches datastore or any other GAE service, to make sure the backend runs properly on staging and prod.
