### PR TITLE
Beginnings of live module

### DIFF
--- a/app/elements/elements.html
+++ b/app/elements/elements.html
@@ -25,6 +25,10 @@
 <link rel="import" href="io-logo.html">
 <link rel="import" href="io-toast.html">
 <link rel="import" href="countdown-timer/countdown-timer.html">
+
+<!-- Remove after Phase 3 -->
+<!-- <link rel="import" href="io-live.html"> -->
+<!-- Add back after Phase 3 -->
 <link rel="import" href="experiment-fab.html">
 
 <!-- Homepage -->

--- a/app/elements/io-live.html
+++ b/app/elements/io-live.html
@@ -1,0 +1,116 @@
+<!--
+Copyright 2015 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../bower_components/google-youtube/google-youtube.html">
+
+<!--
+The `<io-live>` provides the Google I/O live stream experience.
+
+@element io-live
+-->
+<!--
+Fired when the mode changes.
+
+@event io-live-mode
+-->
+<polymer-element name="io-live">
+  <template>
+    <link rel="stylesheet" href="io-live.css">
+
+    <div class="bottom__bar" layout horizontal end justified>
+      <div>
+        <template if="{{mode === _MODES.PRE}}">
+          <content></content>
+        </template>
+      </div>
+      <paper-fab icon="picture-in-picture" aria-label="My schedule" title="My schedule" on-click="{{onFabClick}}"></paper-fab>
+    </div>
+
+    <template if="{{mode === _MODES.LIVE}}">
+      <div class="fullvideo__container" fit>
+        <!-- <img src="{{''}}images/home/recap-500@2x.jpg" class="fullvideo_thumbnail" alt="Watch I/O Live" fit> -->
+        <google-youtube videoid="ksvdvCDO7pA" height="100%" width="100%" fit
+                        autohide="1" controls="2" modestbranding="1" showinfo="0"
+                        iv_load_policy="3" rel="0" autoplay="1"></google-youtube>
+      </div>
+    </template>
+
+    <template if="{{mode === _MODES.PRE}}">
+      <countdown-timer role="timer" bgcolor="#00BCD4" date="[[date]]"
+          easeintime="490" waittime="100" easeouttime="400"
+          value="{{countdownValue}}" autoStart
+          aria-label="{{countdownValue.days}} days, {{countdownValue.hours}} hours, {{countdownValue.minutes}} minutes, {{countdownValue.seconds}} seconds, until Google I/O">
+      </countdown-timer>
+    </template>
+
+  </template>
+  <script>
+  Polymer({
+
+    _MODES: {LIVE: 'live', PRE: 'pre'},
+
+    publish: {
+      /**
+       * The target date for the event. Should be specified in ISO 8601
+       * format, e.g. 'May 28 2015 09:00:00 GMT-0700 (PDT)'.
+       *
+       * @attribute date
+       * @type string
+       * @default 'May 28 2015 09:00:00 GMT-0700 (PDT)'
+       */
+      date: 'May 28 2015 09:00:00 GMT-0700 (PDT)',
+
+      /**
+       * The mode of operation for the live embed. 'pre' is before the event
+       * starts (e.g. before `date`) and a countdown is shown leading up to the
+       * event. 'live' signifies the event has already started and the live
+       * stream video mode should be shown.
+       *
+       * @attribute mode
+       * @type string
+       * @default ''
+       */
+      mode: {
+        value: '', reflect: true
+      }
+    },
+
+    eventDelegates: {
+      'click': 'toggleVideo'
+    },
+
+    domReady: function() {
+      var now = new Date();
+      var eventStart = new Date(this.date);
+      if (now > eventStart) {
+        this.mode = this._MODES.LIVE;
+      } else {
+        this.mode = 'pre';
+      }
+    },
+
+    modeChanged: function() {
+      this.fire('io-live-mode', {mode: this.mode});
+    },
+
+    toggleVideo: function(e, detail, sender) {
+      this.mode = this._MODES.LIVE;
+    },
+
+    onFabClick: function(e, detail, sender) {
+      e.stopPropagation();
+    }
+  });
+  </script>
+</polymer-element>

--- a/app/elements/io-live.scss
+++ b/app/elements/io-live.scss
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '_elements';
+
+:host {
+  display: block;
+}
+
+countdown-timer {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.bottom__bar {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  box-sizing: border-box;
+  z-index: 5; // same as #navbar
+  width: 100%;
+
+  padding: $mobileKeyline;
+
+  ::content h2 {
+    color: inherit;
+    font-weight: 300;
+    line-height: 1;
+  }
+
+  h2 {
+    color: $color-heading;
+    @include typo-heading-2();
+    margin: 0;
+
+    color: inherit;
+    font-weight: 300;
+  }
+
+  paper-fab {
+    background-color: #fff;
+    background: #fff;
+    color: $color-fab-icon;
+    z-index: 2;
+  }
+}
+
+.fullvideo__container {
+  z-index: 1;
+
+  // .fullvideo_thumbnail {
+  //   width: 100%;
+  //   height: 100%;
+
+  //   &.fadeout {
+  //     opacity: 0;
+  //     pointer-events: none;
+  //   }
+  // }
+}
+
+@media (min-width: $tablet-breakpoint-min) {
+  .bottom__bar {
+    padding: $desktopKeyline;
+  }
+}
+
+@media (min-width: $desktop-breakpoint-mid) {
+  .bottom__bar {
+    padding: $largeKeyline;
+  }
+}
+
+

--- a/app/elements/io-logo.html
+++ b/app/elements/io-logo.html
@@ -203,7 +203,7 @@ Fired when loading animation is complete.
       this.backgroundTarget = this.parentElement.querySelector('[iologobackground]');
       this.masthead = document.querySelector('.masthead');
       this.destination = document.querySelector('[iologodestination]');
-      this.fab = document.querySelector('experiment-fab-container');
+      this.fab = document.querySelector('#fab');
 
       var current = this.getBoundingClientRect();
       var dest = this.destination.getBoundingClientRect();
@@ -290,13 +290,17 @@ Fired when loading animation is complete.
           document.timeline.play(
             new AnimationGroup([fabAnimation, mastheadClipAnimation]
           )).onfinish = function(e) {
-            this.fab.style.transform = 'none'; // Remove transform.
+            if (this.fab.localName === 'experiment-fab-container') {
+              this.fab.style.transform = 'none'; // Remove transform.
+            }
             this.fab.style.zIndex = 'auto';
             el.parentElement.removeChild(el);
             this.fire('io-logo-animation-done');
           }.bind(this);
         } else {
-          this.fab.style.zIndex = 'auto';
+          if (this.fab.localName === 'experiment-fab-container') {
+            this.fab.style.zIndex = 'auto';
+          }
           el.parentElement.removeChild(el);
           this.fire('io-logo-animation-done');
         }

--- a/app/scripts/helper/elements.js
+++ b/app/scripts/helper/elements.js
@@ -67,8 +67,25 @@ IOWA.Elements = (function() {
           showSigninHelp(); // show signin help popup on page load.
         }
       );
-
     });
+
+    var ioLive = document.querySelector('io-live');
+    if (ioLive) {
+      var onLiveMode_ = function(e) {
+        if (e.detail.mode === 'live') {
+          var els = [IOWA.Elements.Masthead, IOWA.Elements.NavPaperTabs,
+                     IOWA.Elements.Masthead.querySelector('#signin-nav-elements')];
+          els.forEach(function(el) {
+            el.classList.remove('bg-cyan');
+            el.classList.add('bg-photo');
+          });
+
+          ioLive.removeEventListener('io-live-mode', onLiveMode_);
+        }
+      };
+
+      ioLive.addEventListener('io-live-mode', onLiveMode_);
+    }
 
     var main = document.querySelector('.io-main');
 
@@ -83,7 +100,7 @@ IOWA.Elements = (function() {
     var nav = masthead.querySelector('#navbar');
     var navPaperTabs = nav.querySelector('paper-tabs');
     var drawerMenu = document.getElementById('drawer-menu');
-    var fab = masthead.querySelector('experiment-fab-container');
+    var fab = masthead.querySelector('#fab');
     var footer = document.querySelector('footer');
     var toast = document.getElementById('toast');
     var liveStatus = document.getElementById('live-status');

--- a/app/styles/base/_color.scss
+++ b/app/styles/base/_color.scss
@@ -41,3 +41,5 @@ $color-light-grey-border: #eee;
 $color-form-controls: #009688;
 
 $color-session-detail-light-grey: #BDBDBD;
+
+$color-fab-icon: #616161;

--- a/app/styles/base/_zindex.scss
+++ b/app/styles/base/_zindex.scss
@@ -27,7 +27,7 @@ paper-fab {
   z-index: 2;
 }
 
-experiment-fab-container {
+experiment-fab-container, #fab {
   z-index: 3;
 }
 

--- a/app/styles/components/_app.scss
+++ b/app/styles/components/_app.scss
@@ -109,6 +109,10 @@ h6 {
 
 .bg-photo {
   background-color: $color-bluegrey-700;
+
+  h1, h2, h3, h4 {
+    color: inherit;
+  }
 }
 
 .bg-cyan {

--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -282,11 +282,17 @@ core-drawer-panel {
   line-height: 20px;
 }
 
-experiment-fab-container {
+experiment-fab-container, #fab {
   bottom: -20px; // experiment-fab's height / 2
   right: $mobileKeyline;
   width: 56px;
   height: 56px;
+}
+
+paper-fab {
+  background: #fff;
+  position: absolute;
+  color: $color-fab-icon;
 }
 
 @media (max-width: $phone-breakpoint-max) {
@@ -328,7 +334,7 @@ experiment-fab-container {
     padding: 0 0 170px 0;
   }
 
-  experiment-fab-container {
+  experiment-fab-container, #fab {
     bottom: -28px; // experiment-fab's height / 2
     right: $desktopKeyline;
   }

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -348,15 +348,22 @@ limitations under the License.
             <template id="template-masthead-container" ref="" bind>{% template "masthead" .%}</template>
           </div>
         </div>
-
-        <experiment-fab-container mini?="{{isPhoneSize}}" mode="{{mode}}" playmode="{{playmode}}" recordmode="{{recordmode}}" direction="{{direction}}"></experiment-fab-container>
+        <experiment-fab-container id="fab" mini?="{{isPhoneSize}}" mode="{{mode}}" playmode="{{playmode}}" recordmode="{{recordmode}}" direction="{{direction}}"></experiment-fab-container>
+        <!-- <paper-fab id="fab" icon="event" hidden?="{{selectedPage === 'home'}}"></paper-fab> -->
       </header>
 
-      <main class="io-main {{ {transitionIn: pageTransitioningIn, transitionOut: pageTransitioningOut} | tokenList }}" >
+      <!-- <div id="iolive" hidden?="{{selectedPage != 'home'}}" fit>
+        <io-live mode="{{liveModuleMode}}" date="May 28 2015 09:00:00 GMT-0700 (PDT)" fit>
+          <h2>I/O is starting soon. #io15</h2>
+        </io-live>
+      </div> -->
+
+      <main class="io-main {{ {transitionIn: pageTransitioningIn, transitionOut: pageTransitioningOut} | tokenList }}">
         <template id="template-content-container" ref="" bind>{% template "content" .%}</template>
       </main>
 
       <footer layout vertical>
+      <!-- <footer layout vertical hidden?="{{selectedPage === 'home'}}"> -->
 
         <i18n-msg id="share-text" msgid="share-text" hidden>#io15 brings together devs to explore the next generation of tech and mobile. Join us online or in person May 28-29: https://google.com/io</i18n-msg>
 


### PR DESCRIPTION
R: all, @jeffposnick @crhym3 

Beginnings of #851. I commented out the new bits for now so there's no way you can test this out. But it's essentially the two views:

![screen shot 2015-04-11 at 1 45 15 pm](https://cloud.githubusercontent.com/assets/238208/7103195/046b12de-e051-11e4-892f-7632ee452bbe.png)

The video view comes up if you're past the start of IO (9AM May 28). There is still a lot of style tweaking to do with animations and I need to implement the widget.
