### PR TITLE
Update ioext API path to api/v1/extended

### DIFF
--- a/app/templates/offsite.html
+++ b/app/templates/offsite.html
@@ -135,7 +135,7 @@
                        noDraw?="{{mode === 'active'}}"
                        webglSupported="{{webglSupported}}"></webgl-globe>
 
-          <core-ajax url="api/extended" handleAs="json"
+          <core-ajax url="api/v1/extended" handleAs="json"
                      auto?="{{pageTransitionDone && !offsiteLocations}}"
                      response="{{offsiteLocations}}"></core-ajax>
         </div>

--- a/backend/handler.go
+++ b/backend/handler.go
@@ -25,10 +25,7 @@ var rootHandleFn func(http.ResponseWriter, *http.Request)
 // registerHandlers sets up all backend handle funcs, including the API.
 func registerHandlers() {
 	handle("/", rootHandleFn)
-	// deprecated API endpoints
-	handle("/api/extended", serveIOExtEntries)
-	handle("/api/social", serveSocial)
-	// v1 API endpoints
+	handle("/api/v1/extended", serveIOExtEntries)
 	handle("/api/v1/social", serveSocial)
 	handle("/api/v1/auth", handleAuth)
 	handle("/api/v1/schedule", serveSchedule)

--- a/backend/handler_test.go
+++ b/backend/handler_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestServeIOExtEntriesStub(t *testing.T) {
-	r := newTestRequest(t, "GET", "/api/extended", nil)
+	r := newTestRequest(t, "GET", "/api/v1/extended", nil)
 	w := httptest.NewRecorder()
 	serveIOExtEntries(w, r)
 


### PR DESCRIPTION
This completes the migration to version-prefixed backend api.
