### PR TITLE
Caching for speaker profile images.

### DIFF
--- a/app/scripts/shed/profile-images.js
+++ b/app/scripts/shed/profile-images.js
@@ -7,5 +7,4 @@ function profileImageRequest(request) {
 }
 
 shed.precache([DEFAULT_PROFILE_IMAGE_URL]);
-shed.router.get('/(.+)/images/speakers/(.*)', profileImageRequest,
-  {origin: /https?:\/\/storage\.googleapis\.com/});
+shed.router.get('/(.+)/images/speakers/(.*)', profileImageRequest, {origin: /.*\.googleapis\.com/});


### PR DESCRIPTION
R: @ebidel @devnook @wibblymat 

It uses a `cacheFirst` policy, meaning that if we have an existing copy of the speaker profile image in the cache, use it. Otherwise, try to get a copy from the network.

If both those fail, fall back to a generic `images/touch/homescreen96.png` image.
