### PR TITLE
SW: push event updates to match the latest API response.

### DIFF
--- a/app/scripts/shed/push-notifications.js
+++ b/app/scripts/shed/push-notifications.js
@@ -86,7 +86,7 @@ function processResponse(body) {
  */
 function generateSessionNotifications(updatedSessions) {
   // Ensure that we have an up-to-date sessions feed cached.
-  // This will happen aysnchronously, independent from the notification creation, so it's should not
+  // This will happen aysnchronously, independent from the notification creation, so it shouldn't be
   // necessary to wait on the promise resolutions.
   shed.helpers.openCache().then(function(cache) {
     cache.match(SESSIONS_ENDPOINT).then(function(response) {


### PR DESCRIPTION
Still not tested end-to-end, but given the updates made to the API response format at https://github.com/GoogleChrome/ioweb2015/blob/master/docs/API.md#get-apiv1userupdates, I wanted to get corresponding updates made to the service worker code.

I also wired up the logic to open the session details page corresponding to the updated session now that we know that URL. (@devnook @ebidel please confirm that `schedule?filters=#<sessionId>` is the proper URL to use.) Using the `notification.tag` field to store the URL of the page to open in the `notificationclick` handler is somewhat hacky, but the alternative would be to stash the URL temporarily in IndexedDB, and there's no real benefit of doing that.
