### PR TITLE
Increase HTTP client timeout to 10 sec

### DIFF
--- a/backend/server_gae.go
+++ b/backend/server_gae.go
@@ -28,7 +28,7 @@ func init() {
 	httpTransport = func(c context.Context) http.RoundTripper {
 		return &urlfetch.Transport{
 			Context:  c,
-			Deadline: 3 * time.Second,
+			Deadline: 10 * time.Second,
 		}
 	}
 	// staging instance is accessed only by whitelisted people/domains

--- a/backend/transport.go
+++ b/backend/transport.go
@@ -16,14 +16,14 @@ var httpTransport = func(_ context.Context) http.RoundTripper {
 }
 
 // httpClient create a new HTTP client using httpTransport(),
-// setting request timeout to 3 seconds if supported.
+// setting request timeout to 10 seconds if supported.
 func httpClient(c context.Context) *http.Client {
 	cl := &http.Client{Transport: httpTransport(c)}
 	type canceler interface {
 		CancelRequest(*http.Request)
 	}
 	if _, ok := cl.Transport.(canceler); ok {
-		cl.Timeout = 3 * time.Second
+		cl.Timeout = 10 * time.Second
 	}
 	return cl
 }


### PR DESCRIPTION
Unfortunately, Google Drive may take a few seconds to respond to the backend and so 3 sec timeout is not always enough.

Thing is, we can't control it. Our backend latency will depend on gdrive for `/api/v1/user/schedule/...`

R @ebidel 
