### PR TITLE
Fixes #989

### DIFF
--- a/app/elements/io-schedule.html
+++ b/app/elements/io-schedule.html
@@ -238,10 +238,6 @@ The `<io-schedule>` element renders a schedule for a given day(s).
         // TODO(devnook): implement
       },
 
-      userChanged: function() {
-
-      },
-
       isFilterSelected: function(filterName) {
         return this.filters.indexOf(filterName) > -1;
       },


### PR DESCRIPTION
R: @devnook 

Once you're logged in, the card should really never show itself again. Currently, it's tied to the page nav animations so it re-runs the WAAPI code that hides it. We should figure out a way to permanently hide UI bits like this once the user it auth'd.
