### PR TITLE
Wrap sign in and notification process in a Promise interface

### DIFF
--- a/app/scripts/helper/auth.js
+++ b/app/scripts/helper/auth.js
@@ -136,7 +136,8 @@ IOWA.Auth = IOWA.Auth || (function() {
   });
 
   /**
-   * Useful to coordinate activities that need to take place after the user has signed in.
+   * Provides a Promise resolved after the user has signed in.
+   * It's useful when delaying activities that can't take place until after the user signs in.
    *
    * Usage:
    * function someUIButtonClicked() {
@@ -145,6 +146,8 @@ IOWA.Auth = IOWA.Auth || (function() {
    *   });
    * }
    *
+   * @param {string} message The text displayed in the toast.
+   *                         Defaults to 'Please sign in'
    * @return {Promise} Resolves once the user is signed in. Does not reject.
    */
   function waitForSignedIn(message) {


### PR DESCRIPTION
R: @ebidel @brendankenny & co.:

This closes #987 in a slightly different manner—instead of modifying the way we handle errors related to not being signed in or to notifications being disabled, this provides two new Promises that can be used to wait before taking action that requires being signed in, or having notifications enabled.

`IOWA.Auth.waitForSignedIn()` will prompt the user to sign in if they're not already, and won't resolve until the user is signed in.

`IOWA.Notifications.waitForPrereqs()` will resolve when all the prerequisites needed to display notifications are fulfilled, and will prompt the user for each step.

Hopefully these make sense. I haven't modified any of the existing code yet to call the new methods—I'd rather get them reviewed first, and then make changes in a follow-up PR.

You can test them out via e.g. `IOWA.Auth.waitForSignedIn().then(function() {console.log('signed in');});` from the DevTools console.
