### PR TITLE
Override roles in subtabs so anchors are read aloud

### DIFF
--- a/app/templates/onsite.html
+++ b/app/templates/onsite.html
@@ -7,11 +7,11 @@
 {% define "masthead" %}
   <h1><i18n-msg msgid="attend-onsite">Attend Onsite</i18n-msg></h1>
   <paper-tabs id="subpage-tabs" class="white" selected="{{pages[selectedPage].selectedSubpage}}" valueattr="label" link>
-    <paper-tab label="event">
+    <paper-tab label="event" role="">
       <a href="#event" data-track-link="onsite-event" data-subpage-link
                        layout horizontal center-center>Event</a>
     </paper-tab>
-    <paper-tab label="travel">
+    <paper-tab label="travel" role="">
       <a href="#travel" data-track-link="onsite-travel"  data-subpage-link
                         layout horizontal center-center>Travel</a>
     </paper-tab>

--- a/app/templates/schedule.html
+++ b/app/templates/schedule.html
@@ -9,19 +9,19 @@
   <div layout horizontal justified>
     <paper-tabs id="subpage-tabs" class="white" valueattr="label" selected="agenda"
                 scrollable?="{{isPhoneSize}}" link>
-      <paper-tab label="agenda">
+      <paper-tab label="agenda" role="">
         <a href="#agenda" data-track-link="schedule-agenda" data-subpage-link
                           layout horizontal center-center>Agenda</a>
       </paper-tab>
-      <paper-tab label="day1">
+      <paper-tab label="day1" role="">
         <a href="#day1" data-track-link="schedule-day1" data-subpage-link
                         layout horizontal center-center>Day 1</a>
       </paper-tab>
-      <paper-tab label="day2">
+      <paper-tab label="day2" role="">
         <a href="#day2" data-track-link="schedule-day2" data-subpage-link
                         layout horizontal center-center>Day 2</a>
       </paper-tab>
-      <paper-tab label="myschedule">
+      <paper-tab label="myschedule" role="">
         <a href="#myschedule" data-track-link="schedule-mysched" data-subpage-link
                            layout horizontal center-center>My Schedule</a>
       </paper-tab>


### PR DESCRIPTION
Related to #359 

anchors inside of tabs are not properly read if a tab has a label. Also filed this as a paper-tabs bug (https://github.com/Polymer/paper-tabs/issues/63)
