### PR TITLE
Fix #986, Fix #806: keyboard only focus states for logo

### DIFF
--- a/app/scripts/helper/a11y.js
+++ b/app/scripts/helper/a11y.js
@@ -22,6 +22,7 @@ IOWA.A11y = IOWA.A11y || (function() {
 
   function init() {
     // Differentiate focus coming from mouse and keyboard.
+    addFocusStates('.io-logo-link');
     addFocusStates('#navbar paper-tabs a');
     document.addEventListener('toast-message', announceLiveChange);
   }

--- a/app/styles/base/a11y.scss
+++ b/app/styles/base/a11y.scss
@@ -3,6 +3,10 @@
 /* Handle focus state for I/O logo home button */
 .io-logo-link:focus {
   outline: none;
+}
+
+.io-logo-link.focused {
+  outline: none;
 
   .io-logo::after {
     display: block;


### PR DESCRIPTION
@ebidel I think this also resolves #806 because the logo is already focused before you can interact with it, so there's no longer any jank.
