### PR TITLE
Fix focus state for sign in anchor

### DIFF
--- a/app/styles/base/a11y.scss
+++ b/app/styles/base/a11y.scss
@@ -60,6 +60,20 @@ paper-tab a:focus {
   background: rgba(255, 255, 255, 0.36);
 }
 
+#signin-nav-elements > .button-link:focus {
+  outline: none;
+}
+
+.bg-dark-grey #signin-nav-elements > .button-link:focus {
+  background: rgba(255, 255, 255, 0.26);
+}
+
+.bg-cyan #signin-nav-elements > .button-link:focus,
+.bg-light-grey #signin-nav-elements > .button-link:focus,
+.bg-medium-grey #signin-nav-elements > .button-link:focus {
+  background: rgba(255, 255, 255, 0.36);
+}
+
 /**
  * Aria live region. Should be "hidden" without actually being
  * hidden, or else aria live polling won't work

--- a/app/styles/components/_masthead.scss
+++ b/app/styles/components/_masthead.scss
@@ -188,6 +188,11 @@ core-drawer-panel {
   background-color: transparent;
   /* Should match Polymer/paper-tabs/paper-tab.css#L17 */
   transition: color .1s cubic-bezier(0.4, 0.0, 1, 1);
+  margin: 0;
+}
+
+#signin-nav-elements > .button-link {
+  padding: 16px 12px;
 }
 
 #signin-settings-panel,


### PR DESCRIPTION
Fixes focus state for Sign In anchor so it looks like the other paper-tabs
