### PR TITLE
GA for notification permissions.

### DIFF
--- a/app/scripts/analytics.js
+++ b/app/scripts/analytics.js
@@ -222,24 +222,14 @@ IOWA.Analytics = IOWA.Analytics || (function(exports) {
    * Permissions API, tracks changes to the notification state as well.
    */
   Analytics.prototype.trackNotificationPermission = function() {
-    ga('send', {
-      hitType: 'event',
-      nonInteraction: true,
-      eventCategory: 'notifications',
-      eventAction: 'startup',
-      eventLabel: exports.Notification ? exports.Notification.permission : 'unsupported'
-    });
+    this.trackEvent('notifications', 'startup',
+      exports.Notification ? exports.Notification.permission : 'unsupported');
 
     if (navigator.permissions) {
+      var thisAnalytics = this;
       navigator.permissions.query({name:'notifications'}).then(function(p) {
         p.onchange = function() {
-          ga('send', {
-            hitType: 'event',
-            nonInteraction: true,
-            eventCategory: 'notifications',
-            eventAction: 'change',
-            eventLabel: this.status
-          });
+          thisAnalytics.trackEvent('notifications', 'change', this.status);
         };
       });
     }


### PR DESCRIPTION
R: @ebidel, all

This adds in GA tracking for both initial notification state at startup and, on browsers that support the Permissions API (Chrome 43+), tracks changes to the notification permissions due to user interaction.

Closes #982 
