### PR TITLE
Cache ioext and social for longer time

### DIFF
--- a/backend/ioext.go
+++ b/backend/ioext.go
@@ -9,7 +9,13 @@ import (
 	"golang.org/x/net/context"
 )
 
-const spreadsheetAuthScope = "https://spreadsheets.google.com/feeds"
+const (
+	spreadsheetAuthScope = "https://spreadsheets.google.com/feeds"
+
+	// ioextCacheTimeout is how long until cached extFeed entries are expired.
+	// The content is still refreshed much earlier via cron jobs.
+	ioextCacheTimeout = 48 * time.Hour
+)
 
 // extFeed is the root element of a Google Sheet feed.
 type extFeed struct {
@@ -48,7 +54,7 @@ func ioExtEntries(c context.Context, refresh bool) ([]*extEntry, error) {
 	data, err := json.Marshal(entries)
 	if err != nil {
 		errorf(c, "ioExtEntries: %v", err)
-	} else if err := cache.set(c, feedURL, data, 2*time.Hour); err != nil {
+	} else if err := cache.set(c, feedURL, data, ioextCacheTimeout); err != nil {
 		errorf(c, "ioExtEntries: cache.put(%q): %v", feedURL, err)
 	}
 

--- a/backend/social.go
+++ b/backend/social.go
@@ -15,7 +15,8 @@ import (
 
 const (
 	// socialCacheTimeout is how long until social entries are expired.
-	socialCacheTimeout = 10 * time.Minute
+	// The content is still refreshed much earlier via cron jobs.
+	socialCacheTimeout = 48 * time.Hour
 
 	// tweetURL is a single tweet URL format.
 	tweetURL = "https://twitter.com/%s/status/%v"


### PR DESCRIPTION
I just saw `/api/v1/extended?refresh` errors in the logs for a few hours - apparently Spearsheets API were temporary timing out. This PR reduces chances of cache misses.
@ebidel 
