### PR TITLE
Allow copy-assets to copy debug templates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,8 +143,12 @@ gulp.task('vulcanize-extended-elements', ['sass'], function() {
 // copy needed assets (images, polymer elements, etc) to /dist directory
 gulp.task('copy-assets', function() {
   var assets = $.useref.assets();
+  var templates = [APP_DIR + '/templates/**/*.html'];
+  if (argv.env == 'prod') {
+    templates.push('!**/templates/debug/**');
+  }
 
-  var templateStream = gulp.src([APP_DIR + '/templates/*.html'], {base: './'})
+  var templateStream = gulp.src(templates, {base: './'})
     .pipe(assets)
     .pipe(assets.restore())
     .pipe($.useref());


### PR DESCRIPTION
That way we can also test push msgs on the staging server.
Currently it doesn't deploy `templates/debug/*` so /io2015/debug/push page doesn't work.
