### PR TITLE
Chrome 42 like strings. Chrome 43 likes doubles

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -7,27 +7,27 @@
     "src": "images/touch/homescreen48.png",
     "sizes": "48x48",
     "type": "image/png",
-    "density": 1.0
+    "density": "1.0"
   }, {
     "src": "images/touch/homescreen72.png",
     "sizes": "72x72",
     "type": "image/png",
-    "density": 1.5
+    "density": "1.5"
   }, {
     "src": "images/touch/homescreen96.png",
     "sizes": "96x96",
     "type": "image/png",
-    "density": 2.0
+    "density": "2.0"
   }, {
     "src": "images/touch/homescreen144.png",
     "sizes": "144x144",
     "type": "image/png",
-    "density": 3.0
+    "density": "3.0"
   }, {
     "src": "images/touch/homescreen192.png",
     "sizes": "192x192",
     "type": "image/png",
-    "density": 4.0
+    "density": "4"
   }],
   "chrome_related_applications": [{
     "platform": "web"


### PR DESCRIPTION
R: @jeffposnick 

Update bug: https://github.com/GoogleChrome/ioweb2015/issues/1070
