### PR TITLE
Ensure notifications checkbox properly reflects global + local state

### DIFF
--- a/app/scripts/helper/auth.js
+++ b/app/scripts/helper/auth.js
@@ -38,24 +38,6 @@ IOWA.Auth = IOWA.Auth || (function() {
     var drawerProfilePic = IOWA.Elements.Drawer.querySelector('.profilepic');
     drawerProfilePic.src = user.picture;
     drawerProfilePic.hidden = false;
-
-    if (IOWA.Notifications.isSupported) {
-      // Set notifications checkbox appropriately in settings UI.
-      // First, check to see if notifications are enabled globally, via an API call to the backend.
-      IOWA.Notifications.isNotifyEnabledPromise().then(function(notify) {
-        if (notify) {
-          // If notifications are on globally, next check to see if there's an existing push manager
-          // subscription for the current browser.
-          IOWA.Notifications.isExistingSubscriptionPromise().then(function(existingSubscription) {
-            // Set user.notify property based on whether there's an existing push manager subscription
-            IOWA.Elements.GoogleSignIn.user.notify = existingSubscription;
-          });
-        } else {
-          // If notifications are off globally, then always set the user.notify to false.
-          IOWA.Elements.GoogleSignIn.user.notify = false;
-        }
-      });
-    }
   }
 
   function clearUserUI() {

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -294,7 +294,8 @@ limitations under the License.
               <img _src="{{currentUser.picture}}" class="profilepic">
               <paper-menu-button>
                 <paper-icon-button icon="io:more-vert" aria-label="Settings"></paper-icon-button>
-                <paper-dropdown id="signin-settings-panel" class="dropdown" halign="right" valign="top">
+                <paper-dropdown id="signin-settings-panel" class="dropdown" halign="right" valign="top"
+                                on-core-overlay-open="{{getNotificationState}}">
                   <div class="card-content" layout horizontal>
                     <div><img _src="{{currentUser.picture}}" class="profilepic"></div>
                     <div>
@@ -305,7 +306,10 @@ limitations under the License.
                   <div class="card-content notification__feature">
                     <h4>Notifications</h4>
                     <core-label horizontal layout>
-                      <paper-checkbox checked?="{{currentUser.notify}}" autoFocus for on-tap="{{updateNotifyUser}}"></paper-checkbox>
+                      <paper-checkbox autoFocus for
+                                      checked?="{{currentUser.notify}}"
+                                      disabled?="{{currentUser.notify === null}}"
+                                      on-tap="{{updateNotifyUser}}"></paper-checkbox>
                       <h5>I want to receive notifications from the Google I/O 2015 web app.</h5>
                     </core-label>
                     <p>If this option is deselected, I understand I won't be notified when:</p>


### PR DESCRIPTION
R: all

The first of a few notifications state-related PRs. This one ensures that when the notifications settings panel is opened, we calculate the proper state for the checkbox. This involves making an asynchronous call to the server to check global notification state, so it's not instantaneous. The checkbox is disabled in the interim.

Fixes #1037
