### PR TITLE
fix webgl-globe scrollthreshold bug

### DIFF
--- a/app/elements/webgl-globe/webgl-globe.html
+++ b/app/elements/webgl-globe/webgl-globe.html
@@ -276,9 +276,9 @@ Fired when the globe's webgl context has been initialized or it failed to initia
        *
        * @property scrollThreshold_
        * @type number
-       * @default 1.7976931348623157e+308
+       * @default -1.7976931348623157e+308
        */
-      scrollThreshold_: Number.MAX_VALUE,
+      scrollThreshold_: -Number.MAX_VALUE,
 
       /**
        * Whether WebGL initialization has been started.


### PR DESCRIPTION
R: @ebidel 

fixes #1072 

`lowerThreshold` is measured from the _bottom_ of the scrollable element. A gigantic positive default `lowerThreshold` means that it's triggered by default.

I assume this was uncovered by the scheduling router changes (possibly the scroll threshold listener only ever fired after `domReady` before?)
