### PR TITLE
Load auth immediately on page load.

### DIFF
--- a/app/scripts/helper/elements.js
+++ b/app/scripts/helper/elements.js
@@ -45,7 +45,7 @@ IOWA.Elements = (function() {
     var ioLogo = document.querySelector('io-logo');
     ioLogo.addEventListener('io-logo-animation-done', function(e) {
       // Loading auth is delayed until logo animation is done.
-      IOWA.Elements.GoogleSignIn.load = true;
+      // IOWA.Elements.GoogleSignIn.load = true;
 
       // Deep link into a subpage.
       var tpl = IOWA.Elements.Template;

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -235,7 +235,7 @@ limitations under the License.
                      user="{{currentUser}}"></google-signin> -->
       <google-signin clientId="{% .ClientID %}"
                      scopes="profile email https://www.googleapis.com/auth/drive.appfolder"
-                     user="{{currentUser}}"></google-signin>
+                     user="{{currentUser}}" load></google-signin>
 
       <!-- Responsive handlers -->
       <core-media-query id="mq-phone" query="(min-width:320px) and (max-width:767px)"


### PR DESCRIPTION
I originally delayed this so the loading animation would be smooth, but it is still not great on mobile. On mobile, auth comes in much later after the log disappears and there's a noticeable delay before you're signed in to the app. Loading gapi immediately on page load makes the user's profile available right away.

R: @crhym3 @jeffposnick 
