### PR TITLE
Enhance signin-prompt animation in schedule

### DIFF
--- a/app/scripts/helper/page-animation.js
+++ b/app/scripts/helper/page-animation.js
@@ -296,11 +296,10 @@ IOWA.PageAnimation = (function() {
    * Moves the delaySection down, shows the card and slides it in.
    * @param {Element} card The card to slide in.
    * @param {Element} delaySection Section that follows up.
+   * @param {Number} slideLength How far to slide out.
    * @return {Animation} Card animation definition.
    */
   function topCardSlideIn(card, delaySection, slideLength) {
-    var slideLength = (card.getBoundingClientRect().top -
-                       delaySection.getBoundingClientRect().top);
     var slideDown = new AnimationGroup([
       new Animation(card, [
         {
@@ -326,11 +325,10 @@ IOWA.PageAnimation = (function() {
    * Slides the card up, hides it and moves the delaySection up.
    * @param {Element} card The card to slide in.
    * @param {Element} delaySection Section that follows up.
+   * @param {Number} slideLength How far to slide out.
    * @return {Animation} Card animation definition.
    */
-  function topCardSlideOut(card, delaySection) {
-    var slideLength = Math.floor(card.getBoundingClientRect().top -
-                       delaySection.getBoundingClientRect().top);
+  function topCardSlideOut(card, delaySection, slideLength) {
     var slideUp = new AnimationGroup([
       new Animation(card, [
         {

--- a/app/templates/schedule.html
+++ b/app/templates/schedule.html
@@ -295,7 +295,7 @@
             signinPropmt.style.visibility = 'visible';
             // Change opacity and slide in.
             IOWA.PageAnimation.play(IOWA.PageAnimation.topCardSlideIn(
-              signinPropmt, delaySection), function() {
+              signinPropmt, delaySection, slideLength), function() {
               delaySection.removeAttribute('data-slide-length');
             });
         });


### PR DESCRIPTION
Changes the signin prompt card animation to slideIn/slideOut, so that it matches the feeling of the rest of the page.

To try out, go to /schedule, select a day, and sign in. Card should slide out of the view.
