### PR TITLE
Bail out of getNotificationState if the overlay is being closed.

### DIFF
--- a/app/scripts/helper/elements.js
+++ b/app/scripts/helper/elements.js
@@ -540,7 +540,14 @@ IOWA.Elements = (function() {
     // global notifications are enabled, the current browser has a push subscription,
     // and window.Notification.permission === 'granted'.
     // Updates IOWA.Elements.GoogleSignIn.user.notify = false otherwise.
-    template.getNotificationState = function() {
+    template.getNotificationState = function(e, detail, sender) {
+      // The core-overlay-open event that invokes this is called once when the overlay opens, and
+      // once when it closes. We only want this code to run when the overlay opens.
+      // detail is true when the setting panel is opened, and false when it's closed.
+      if (!detail) {
+        return;
+      }
+
       // This sends a signal to the template that we're still calculating the proper state, and
       // that the checkbox should be disabled for the time being.
       IOWA.Elements.GoogleSignIn.user.notify = null;


### PR DESCRIPTION
@ebidel (reported by @crhym3)

I forgot how Polymer overloaded these events... the fact that `core-overlay-open` fires when the overlay is being closed has probably bitten a lot peopel.
