### PR TITLE
Throttle /sync/gcs requests

### DIFF
--- a/backend/cache.go
+++ b/backend/cache.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -21,6 +23,10 @@ var (
 type cacheInterface interface {
 	// set puts data bytes into the cache under key for the duration of the exp.
 	set(c context.Context, key string, data []byte, exp time.Duration) error
+	// inc atomically increments the decimal value in the given key by delta
+	// and returns the new value. The value must fit in a uint64. Overflow wraps around,
+	// and underflow is capped to zero
+	inc(c context.Context, key string, delta int64, initialValue uint64) (uint64, error)
 	// get gets data from the cache put under key.
 	// it returns errCacheMiss if item is not in the cache or expired.
 	get(c context.Context, key string) ([]byte, error)
@@ -50,6 +56,33 @@ func (mc *memoryCache) set(c context.Context, key string, data []byte, exp time.
 	defer mc.Unlock()
 	mc.items[key] = &cacheItem{data, time.Now().Add(exp)}
 	return nil
+}
+
+func (mc *memoryCache) inc(c context.Context, key string, delta int64, initialValue uint64) (uint64, error) {
+	mc.Lock()
+	defer mc.Unlock()
+	item, ok := mc.items[key]
+	if !ok {
+		var z time.Time
+		b := make([]byte, binary.Size(initialValue))
+		binary.PutUvarint(b, initialValue)
+		item = &cacheItem{b, z}
+		mc.items[key] = item
+	}
+	v, n := binary.Uvarint(item.data)
+	if n <= 0 {
+		return 0, fmt.Errorf("inc: binary.Uvarint error: %d", n)
+	}
+	switch {
+	case delta < 0 && v < uint64(delta):
+		v = 0
+	case delta < 0:
+		v -= uint64(delta)
+	case delta > 0:
+		v += uint64(delta)
+	}
+	binary.PutUvarint(item.data, v)
+	return v, nil
 }
 
 func (mc *memoryCache) get(c context.Context, key string) ([]byte, error) {

--- a/backend/cache_gae.go
+++ b/backend/cache_gae.go
@@ -21,6 +21,10 @@ func (mc *gaeMemcache) set(c context.Context, key string, data []byte, exp time.
 	return memcache.Set(c, item)
 }
 
+func (mc *gaeMemcache) inc(c context.Context, key string, delta int64, initial uint64) (uint64, error) {
+	return memcache.Increment(c, key, delta, initial)
+}
+
 func (mc *gaeMemcache) get(c context.Context, key string) ([]byte, error) {
 	item, err := memcache.Get(c, key)
 	if err == memcache.ErrCacheMiss {

--- a/backend/cache_test.go
+++ b/backend/cache_test.go
@@ -49,6 +49,29 @@ func TestMemoryCacheMiss(t *testing.T) {
 	}
 }
 
+func TestMemoryCacheInc(t *testing.T) {
+	mc := newMemoryCache()
+	c := context.Background()
+
+	table := []struct {
+		delta   int64
+		initVal uint64
+		res     uint64
+	}{
+		{3, 1, 4}, {1, 0, 5}, {-5, 0, 0}, {10, 0, 10}, {-100, 0, 0},
+	}
+
+	for i, test := range table {
+		v, err := mc.inc(c, "test", test.delta, test.initVal)
+		if err != nil {
+			t.Fatalf("%d: inc(%d, %d)", i, test.delta, test.initVal)
+		}
+		if v != test.res {
+			t.Errorf("%d: inc(%d, %d) = %d; want %d", i, test.delta, test.initVal, v, test.res)
+		}
+	}
+}
+
 func TestMemoryCacheFlush(t *testing.T) {
 	mc := newMemoryCache()
 	c := context.Background()


### PR DESCRIPTION
This also improves fetching protected GCS bucket by reusing the same HTTP client, and thus credentials, for all files of the manifest.

Fixes #1139
