### PR TITLE
Moves auth loading back to after logo animation is done. Was janky again

### DIFF
--- a/app/elements/countdown-timer/countdown-timer.html
+++ b/app/elements/countdown-timer/countdown-timer.html
@@ -51,8 +51,8 @@ Creates a countdown timer to a specific date.
         display: block;
         width: 100%;
         height: 100%;
-        transition: opacity 400ms cubic-bezier(0,0,0.2,1);
-        opacity: 0;
+        /*transition: opacity 400ms cubic-bezier(0,0,0.2,1);*/
+        /*opacity: 0;*/
       }
 
       .countdown-timer,
@@ -69,34 +69,6 @@ Creates a countdown timer to a specific date.
       lowerTriggered="{{ lowerTriggered }}"
       lowerThreshold="{{ lowerThreshold }}">
     </core-scroll-threshold>
-
-    <!--<template if="{{ thresholdDays }}">
-      <h4 class="countdown-label">
-        <i18n-msg msgid="days">Days</i18n-msg>
-        <content></content>
-      </h4>
-    </template>
-
-    <template if="{{ thresholdHours }}">
-      <h4 class="countdown-label">
-        <i18n-msg msgid="hours">Hours</i18n-msg>
-        <content></content>
-      </h4>
-    </template>
-
-    <template if="{{ thresholdMinutes }}">
-      <h4 class="countdown-label">
-        <i18n-msg msgid="minutes">Minutes</i18n-msg>
-        <content></content>
-      </h4>
-    </template>
-
-    <template if="{{ thresholdSeconds }}">
-      <h4 class="countdown-label">
-        <i18n-msg msgid="seconds">Seconds</i18n-msg>
-        <content></content>
-      </h4>
-    </template> -->
 
   </template>
   <script>
@@ -337,6 +309,7 @@ Creates a countdown timer to a specific date.
         }
 
         this.start();
+        this.show();
       },
 
       thresholdInformation: null,

--- a/app/scripts/helper/elements.js
+++ b/app/scripts/helper/elements.js
@@ -44,6 +44,11 @@ IOWA.Elements = (function() {
   function updateElements() {
     var ioLogo = document.querySelector('io-logo');
     ioLogo.addEventListener('io-logo-animation-done', function(e) {
+      // Load auth after logo transition is done. This helps timing with
+      // fetching user's schedule and makes sure the worker has returned
+      // the main schedule data.
+      IOWA.Elements.GoogleSignIn.load = true;
+
       // Deep link into a subpage.
       var tpl = IOWA.Elements.Template;
       var parsedUrl = IOWA.Router.parseUrl(window.location.href);
@@ -57,11 +62,6 @@ IOWA.Elements = (function() {
 
       IOWA.PageAnimation.play(
         IOWA.PageAnimation.pageFirstRender(subpage), function() {
-          // // Load auth after page transitions are done. This helps timing with
-          // // fetching user's schdule and makes sure the worker has returned
-          // // the main schedule data.
-          // IOWA.Elements.GoogleSignIn.load = true;
-
           // Fire event when the page transitions are final.
           IOWA.Elements.Template.fire('page-transition-done');
           // Run page's custom onPageTransitionDone handlers, if present.

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -180,14 +180,7 @@
         IOWA.Elements.Template.socialPosts = socialPosts.slice(0, 3);
       }
 
-      // TODO: Move to use page.onPageTransitionDone.
-      function onPageTransitionDone_() {
-        document.removeEventListener('page-transition-done', onPageTransitionDone_);
-        showCountdownTimer();
-      }
-
       page.load = function() {
-        document.addEventListener('page-transition-done', onPageTransitionDone_);
         IOWA.Request.cacheThenNetwork(socialPostsEndpoint, processSocialPosts, processSocialPosts);
         // Set a timeout to fetch new posts after 30 seconds.
         updateSocialPostsTimeout = window.setTimeout(updateSocialPosts, socialPostUpdateInterval);
@@ -198,16 +191,6 @@
         IOWA.Elements.Template.fullscreenVideoActive = false;
         IOWA.Elements.Template.webglSupported = true;
       };
-
-      function showCountdownTimer() {
-
-        var countdownEl = document.querySelector('countdown-timer');
-
-        if (!countdownEl)
-          return;
-
-        countdownEl.show();
-      }
 
       page.unload = function() {
         if (updateSocialPostsTimeout) {

--- a/app/templates/layout_full.html
+++ b/app/templates/layout_full.html
@@ -233,7 +233,7 @@ limitations under the License.
 
       <google-signin clientId="{% .ClientID %}"
                      scopes="https://www.googleapis.com/auth/drive.appfolder"
-                     user="{{currentUser}}" load></google-signin>
+                     user="{{currentUser}}"></google-signin>
 
       <!-- Responsive handlers -->
       <core-media-query id="mq-phone" query="(min-width:320px) and (max-width:767px)"


### PR DESCRIPTION
R: @jeffposnick @crhym3 

This also removes the delay in showing the homepage countdown. It was taking a long time to show up on homepage load on y n6. The tradeoff is that it no longer does a smooth fade-in if you transition back to the homepage, but IMO, showing something faster is better. 
