### PR TITLE
Enable notifications on signin if the global notification state is true

### DIFF
--- a/app/scripts/bootstrap.js
+++ b/app/scripts/bootstrap.js
@@ -154,10 +154,8 @@
       // notifications in the current browser.
       if (window.Notification.permissions !== 'denied') {
         IOWA.Notifications.isNotifyEnabledPromise().then(function(isGlobalNotificationsEnabled) {
-          console.log('isGlobalNotificationsEnabled', isGlobalNotificationsEnabled);
           if (isGlobalNotificationsEnabled) {
             IOWA.Notifications.isExistingSubscriptionPromise().then(function(isLocalSubscription) {
-              console.log('isLocalSubscription', isLocalSubscription);
               if (!isLocalSubscription) {
                 IOWA.Notifications.subscribePromise();
               }


### PR DESCRIPTION
R: @ebidel, all

If `window.Notification.permissions` is set to `"default"` or `"prompt"`, this will result in a browser-native prompt asking the user to allow notifications.

If `window.Notification.permissions` is already set to `"granted"`, then this will enable notifications without any further user intervention, because they've previously granted permission to the site.

Closes #1083
