### PR TITLE
Remove revoked refresh tokens on the backend

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -28,6 +28,12 @@ func storeCredentials(c context.Context, cred *oauth2Credentials) error {
 	return nil
 }
 
+// updateCredentials patches existing Cred entity with the provided new ncred credentials
+// in a transaction.
+func updateCredentials(c context.Context, ncred *oauth2Credentials) error {
+	return errors.New("not implemented")
+}
+
 // getCredentials fetches user credentials from a persistent DB.
 func getCredentials(c context.Context, uid string) (*oauth2Credentials, error) {
 	// TODO: implement

--- a/backend/handler.go
+++ b/backend/handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -662,6 +663,7 @@ func handlePingUser(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errorf(c, err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 	if !pi.Enabled {
 		logf(c, "notifications not enabled")
@@ -677,6 +679,10 @@ func handlePingUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bookmarks, err := userSchedule(c, user)
+	if ue, ok := err.(*url.Error); ok && (ue.Err == errAuthInvalid || ue.Err == errAuthMissing) {
+		errorf(c, "unrecoverable: %v", err)
+		return
+	}
 	if err != nil {
 		errorf(c, "%v", err)
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
This works closely with #1214 and also avoids for async tasks to hang around indefinitely because of revoked refresh tokens.

It should be the last piece to cover all auth-related cases.
