### PR TITLE
Use unique names for SW functions

### DIFF
--- a/app/scripts/shed/offline-analytics.js
+++ b/app/scripts/shed/offline-analytics.js
@@ -2,7 +2,7 @@ var DB_NAME = 'shed-offline-analytics';
 var EXPIRATION_TIME_DELTA = 86400000; // One day, in milliseconds.
 var ORIGIN = /https?:\/\/((www|ssl)\.)?google-analytics\.com/;
 
-function replayQueuedRequests() {
+function replayQueuedAnalyticsRequests() {
   simpleDB.open(DB_NAME).then(function(db) {
     db.forEach(function(url, originalTimestamp) {
       var timeDelta = Date.now() - originalTimestamp;
@@ -33,7 +33,7 @@ function replayQueuedRequests() {
   });
 }
 
-function queueFailedRequest(request) {
+function queueFailedAnalyticsRequest(request) {
   console.log('Queueing failed request:', request);
 
   simpleDB.open(DB_NAME).then(function(db) {
@@ -51,11 +51,11 @@ function handleAnalyticsCollectionRequest(request) {
       return response;
     }
   }).catch(function() {
-    queueFailedRequest(request);
+    queueFailedAnalyticsRequest(request);
   });
 }
 
 shed.router.get('/collect', handleAnalyticsCollectionRequest, {origin: ORIGIN});
 shed.router.get('/analytics.js', shed.networkFirst, {origin: ORIGIN});
 
-replayQueuedRequests();
+replayQueuedAnalyticsRequests();

--- a/app/scripts/shed/offline-session-updates.js
+++ b/app/scripts/shed/offline-session-updates.js
@@ -1,6 +1,6 @@
 var QUEUED_SESSION_UPDATES_DB_NAME = 'shed-offline-session-updates';
 
-function queueFailedRequest(request) {
+function queueFailedSessionUpdateRequest(request) {
   console.log('Queueing failed request:', request);
 
   simpleDB.open(QUEUED_SESSION_UPDATES_DB_NAME).then(function(db) {
@@ -13,7 +13,7 @@ function queueFailedRequest(request) {
   });
 }
 
-function handleQueueableRequest(request) {
+function handleSessionUpdateRequest(request) {
   return fetch(request).then(function(response) {
     if (response.status >= 500) {
       // This will cause the promise to reject, triggering the .catch() function.
@@ -23,9 +23,9 @@ function handleQueueableRequest(request) {
       return response;
     }
   }).catch(function() {
-    queueFailedRequest(request);
+    queueFailedSessionUpdateRequest(request);
   });
 }
 
-shed.router.put('/(.+)api/v1/user/schedule/(.+)', handleQueueableRequest);
-shed.router.delete('/(.+)api/v1/user/schedule/(.+)', handleQueueableRequest);
+shed.router.put('/(.+)api/v1/user/schedule/(.+)', handleSessionUpdateRequest);
+shed.router.delete('/(.+)api/v1/user/schedule/(.+)', handleSessionUpdateRequest);


### PR DESCRIPTION
R: @ebidel, all

Everything pulled in via `importScripts()` shares the top-level `ServiceWorkerGlobalScope`, so two different files can't have functions named the same thing.

In lieu of doing something explicit like `IOWA.SW.blah` scoping for each file, I'm just making the function names more verbose.

Closes https://github.com/GoogleChrome/ioweb2015/issues/1239
