### PR TITLE
Avoid additional SW scope naming conflicts

### DIFF
--- a/app/scripts/shed/offline-analytics.js
+++ b/app/scripts/shed/offline-analytics.js
@@ -1,9 +1,9 @@
-var DB_NAME = 'shed-offline-analytics';
+var OFFLINE_ANALYTICS_DB_NAME = 'shed-offline-analytics';
 var EXPIRATION_TIME_DELTA = 86400000; // One day, in milliseconds.
 var ORIGIN = /https?:\/\/((www|ssl)\.)?google-analytics\.com/;
 
 function replayQueuedAnalyticsRequests() {
-  simpleDB.open(DB_NAME).then(function(db) {
+  simpleDB.open(OFFLINE_ANALYTICS_DB_NAME).then(function(db) {
     db.forEach(function(url, originalTimestamp) {
       var timeDelta = Date.now() - originalTimestamp;
       // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
@@ -36,7 +36,7 @@ function replayQueuedAnalyticsRequests() {
 function queueFailedAnalyticsRequest(request) {
   console.log('Queueing failed request:', request);
 
-  simpleDB.open(DB_NAME).then(function(db) {
+  simpleDB.open(OFFLINE_ANALYTICS_DB_NAME).then(function(db) {
     db.set(request.url, Date.now());
   });
 }

--- a/app/scripts/shed/push-notifications.js
+++ b/app/scripts/shed/push-notifications.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-var DB_KEY = 'token';
-var DB_NAME = 'push-notification-updates';
+var NOTIFICATION_UPDATES_DB_KEY = 'token';
+var NOTIFICATION_UPDATES_DB_NAME = 'push-notification-updates';
 var DEFAULT_ICON = 'images/touch/homescreen192.png';
 var SCHEDULE_ENDPOINT = 'api/v1/schedule';
 var UPDATES_ENDPOINT = 'api/v1/user/updates';
@@ -31,8 +31,8 @@ var UTM_SOURCE_PARAM = 'utm_source=notification';
  * @return {Promise} Resolves with the token, or null if there isn't one.
  */
 function loadToken() {
-  return simpleDB.open(DB_NAME).then(function(db) {
-    return db.get(DB_KEY).then(function(token) {
+  return simpleDB.open(NOTIFICATION_UPDATES_DB_NAME).then(function(db) {
+    return db.get(NOTIFICATION_UPDATES_DB_KEY).then(function(token) {
       return token;
     });
   });
@@ -151,8 +151,8 @@ function generateSessionNotification(updatedSessions) {
  * @return {Promise} Resolves if the token is written successfully, and rejects otherwise.
  */
 function saveToken(token) {
-  return simpleDB.open(DB_NAME).then(function(db) {
-    return db.set(DB_KEY, token);
+  return simpleDB.open(NOTIFICATION_UPDATES_DB_NAME).then(function(db) {
+    return db.set(NOTIFICATION_UPDATES_DB_KEY, token);
   });
 }
 


### PR DESCRIPTION
R: @ebidel, all

Really relieved that this is just another case of overwriting previously declared variables in the `ServiceWorkerGlobalScope` and not some nasty bug that I had assumed in #1241.

Closes #1241 
