### PR TITLE
Do more to ensure there's always a notification shown

### DIFF
--- a/app/scripts/analytics.js
+++ b/app/scripts/analytics.js
@@ -49,6 +49,12 @@ IOWA.Analytics = IOWA.Analytics || (function(exports) {
 
     this.trackNotificationPermission();
 
+    var matches = exports.location.search.match(/utm_error=([^&]+)/);
+    if (matches) {
+      // Assume that the only time we'll be setting utm_error= is from the notification code.
+      this.trackError('notification', decodeURIComponent(matches[1]));
+    }
+
     /**
      * A collection of timing categories, each a collection of start times.
      * @private {!Object<string, Object<string, ?number>}

--- a/app/scripts/shed/push-notifications.js
+++ b/app/scripts/shed/push-notifications.js
@@ -180,7 +180,7 @@
     // use to the home page.
     if (!relativeUrl) {
       // The URL constructor will handle escaping/URL encoding.
-      relativeUrl = './?utm_content=' + event.notification.tag;
+      relativeUrl = './?utm_error=' + event.notification.tag;
     }
 
     var url = new URL(relativeUrl, global.location.href);


### PR DESCRIPTION
R: @ebidel, all

Closes #1264, by moving the notification fallback code to the `catch()` of the `push` event.

It also will serialize the error that prevented the "real" notification from being shown into the `utm_content=` param, so we should theoretically be able to find out about any common error conditions via Google Analytics.

I don't know if the string "Some events in My Schedule have been updated" should be used for default notification title—something more generic might make more sense. Once the session video notifications are implemented it may make sense to tweak that.
