### PR TITLE
widen offsite search radius to 150km

### DIFF
--- a/app/templates/offsite.html
+++ b/app/templates/offsite.html
@@ -291,7 +291,7 @@
         IOWA.Elements.Template.offsiteMarkerResults= [];
 
         // Offsite event search radius in kilometers.
-        IOWA.Elements.Template.offsiteSearchRadius = 80;
+        IOWA.Elements.Template.offsiteSearchRadius = 150;
       };
 
       page.scrollToJoin = function() {


### PR DESCRIPTION
fixes #1266

in dense places this might be excessive. If it is, we could do something like redo the search within 80km or something in cases of too many results.
