### PR TITLE
Limit number of task retries on the backend

### DIFF
--- a/backend/handler.go
+++ b/backend/handler.go
@@ -20,18 +20,23 @@ import (
 	"golang.org/x/net/context"
 )
 
-// syncGCSCacheKey guards GCS sync task against choking
-// when requests coming too fast.
-const syncGCSCacheKey = "sync:gcs"
+const (
+	// maxTaskRetry is the default max number of a task retries.
+	maxTaskRetry = 10
+	// syncGCSCacheKey guards GCS sync task against choking
+	// when requests coming too fast.
+	syncGCSCacheKey = "sync:gcs"
+)
 
-// wrapHandler is the last in a handler chain call,
-// which wraps all app handlers.
-// GAE and standalone servers have different wrappers, hence a variable.
-var wrapHandler func(http.Handler) http.Handler
-
-// rootHandleFn is a request handler func for config.Prefix pattern.
-// GAE and standalone servers have different root handle func.
-var rootHandleFn func(http.ResponseWriter, *http.Request)
+var (
+	// wrapHandler is the last in a handler chain call,
+	// which wraps all app handlers.
+	// GAE and standalone servers have different wrappers, hence a variable.
+	wrapHandler func(http.Handler) http.Handler
+	// rootHandleFn is a request handler func for config.Prefix pattern.
+	// GAE and standalone servers have different root handle func.
+	rootHandleFn func(http.ResponseWriter, *http.Request)
+)
 
 // registerHandlers sets up all backend handle funcs, including the API.
 func registerHandlers() {
@@ -622,12 +627,13 @@ func serveSWToken(w http.ResponseWriter, r *http.Request) {
 
 // TODO: add ioext params
 func handleNotifySubscribers(w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("x-appengine-taskname") == "" {
-		w.WriteHeader(http.StatusUnauthorized)
+	c := newContext(r)
+	retry, err := taskRetryCount(r)
+	if err != nil || retry > maxTaskRetry {
+		errorf(c, "retry = %d, err: %v", retry, err)
 		return
 	}
 
-	c := newContext(r)
 	sessions := strings.Split(r.FormValue("sessions"), " ")
 	if len(sessions) == 0 {
 		logf(c, "handleNotifySubscribers: empty sessions list; won't notify")
@@ -652,12 +658,13 @@ func handleNotifySubscribers(w http.ResponseWriter, r *http.Request) {
 
 // handlePingUser schedules a GCM "ping" to user devices based on certain conditions.
 func handlePingUser(w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("x-appengine-taskname") == "" {
-		w.WriteHeader(http.StatusUnauthorized)
+	c := newContext(r)
+	retry, err := taskRetryCount(r)
+	if err != nil || retry > maxTaskRetry {
+		errorf(c, "retry = %d, err: %v", retry, err)
 		return
 	}
 
-	c := newContext(r)
 	user := r.FormValue("uid")
 	pi, err := getUserPushInfo(c, user)
 	if err != nil {
@@ -718,11 +725,13 @@ func handlePingUser(w http.ResponseWriter, r *http.Request) {
 
 // handlePingDevices handles a request to notify a single user device.
 func handlePingDevice(w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("x-appengine-taskname") == "" {
-		w.WriteHeader(http.StatusUnauthorized)
+	c := newContext(r)
+	retry, err := taskRetryCount(r)
+	if err != nil || retry > maxTaskRetry {
+		errorf(c, "retry = %d, err: %v", retry, err)
 		return
 	}
-	c := newContext(r)
+
 	uid := r.FormValue("uid")
 	rid := r.FormValue("rid")
 	endpoint := r.FormValue("endpoint")
@@ -776,16 +785,11 @@ func handlePingDevice(w http.ResponseWriter, r *http.Request) {
 }
 
 // handlePingExt sends a "ping" POST request to config.ExtPingURL.
-// On GAE, it will retry at least 3 times before giving up.
 func handlePingExt(w http.ResponseWriter, r *http.Request) {
 	c := newContext(r)
-	retry, err := strconv.Atoi(r.Header.Get("X-AppEngine-TaskExecutionCount"))
-	if err != nil {
-		errorf(c, "handlePingExt: invalid X-AppEngine-TaskExecutionCount: %v", err)
-		return
-	}
-	if retry > 2 {
-		errorf(c, "handlePingExt: retry = %d; giving up.", retry)
+	retry, err := taskRetryCount(r)
+	if err != nil || retry > maxTaskRetry {
+		errorf(c, "retry = %d, err: %v", retry, err)
 		return
 	}
 
@@ -952,6 +956,15 @@ func errStatus(err error) int {
 	default:
 		return http.StatusInternalServerError
 	}
+}
+
+// taskRetryCount returns the number times the task has been retried.
+func taskRetryCount(r *http.Request) (int, error) {
+	n, err := strconv.Atoi(r.Header.Get("X-AppEngine-TaskExecutionCount"))
+	if err != nil {
+		return -1, fmt.Errorf("taskRetryCount: %v", err)
+	}
+	return n - 1, nil
 }
 
 // toAPISchedule converts eventData to /api/v1/schedule response format.

--- a/backend/handler_test.go
+++ b/backend/handler_test.go
@@ -1317,7 +1317,7 @@ func TestHandlePingExt(t *testing.T) {
 	config.ExtPingURL = ping.URL
 
 	r := newTestRequest(t, "POST", "/task/ping-ext?key=a-key", nil)
-	r.Header.Set("X-AppEngine-TaskExecutionCount", "0")
+	r.Header.Set("x-appengine-taskexecutioncount", "1")
 	w := httptest.NewRecorder()
 	handlePingExt(w, r)
 
@@ -1349,7 +1349,7 @@ func TestHandlePingUserMissingToken(t *testing.T) {
 		"uid":      {testUserID},
 		"sessions": {"one"},
 	}
-	r.Header.Set("x-appengine-taskname", "dummy")
+	r.Header.Set("x-appengine-taskexecutioncount", "1")
 	c := newContext(r)
 
 	if err := storeUserPushInfo(c, &userPush{userID: testUserID, Enabled: true}); err != nil {
@@ -1384,7 +1384,7 @@ func TestHandlePingUserRefokedToken(t *testing.T) {
 		"uid":      {testUserID},
 		"sessions": {"one"},
 	}
-	r.Header.Set("x-appengine-taskname", "dummy")
+	r.Header.Set("x-appengine-taskexecutioncount", "1")
 	c := newContext(r)
 
 	if err := storeUserPushInfo(c, &userPush{userID: testUserID, Enabled: true}); err != nil {
@@ -1442,7 +1442,7 @@ func TestHandlePingDevice(t *testing.T) {
 		"rid":      {"reg-123"},
 		"endpoint": {ts.URL},
 	}
-	r.Header.Set("x-appengine-taskname", "dummy-task")
+	r.Header.Set("x-appengine-taskexecutioncount", "1")
 	w := httptest.NewRecorder()
 	handlePingDevice(w, r)
 
@@ -1474,7 +1474,7 @@ func TestHandlePingDeviceDelete(t *testing.T) {
 		"rid":      {"reg-123"},
 		"endpoint": {ts.URL},
 	}
-	r.Header.Set("x-appengine-taskname", "dummy-task")
+	r.Header.Set("x-appengine-taskexecutioncount", "1")
 
 	c := newContext(r)
 	storeUserPushInfo(c, &userPush{
@@ -1516,7 +1516,7 @@ func TestHandlePingDeviceReplace(t *testing.T) {
 		"rid":      {"reg-123"},
 		"endpoint": {ts.URL},
 	}
-	r.Header.Set("x-appengine-taskname", "dummy-task")
+	r.Header.Set("x-appengine-taskexecutioncount", "1")
 
 	c := newContext(r)
 	storeUserPushInfo(c, &userPush{


### PR DESCRIPTION
Once a task has retried more than `maxTaskRetries`, it is highly unlikely to succeed.
No reason to keep trying indefinitely.
