### PR TITLE
Listen for current SW controller's redundant state

### DIFF
--- a/app/scripts/helper/service-worker-registration.js
+++ b/app/scripts/helper/service-worker-registration.js
@@ -46,7 +46,7 @@ IOWA.ServiceWorkerRegistration = (function() {
                   if (!navigator.serviceWorker.controller) {
                     IOWA.Elements.Toast.showMessage('Caching complete! Future visits will work offline.');
                   }
-                break;
+                  break;
 
                 case 'redundant':
                   throw 'The installing service worker became redundant.';


### PR DESCRIPTION
R: @ebidel & co.

More details are in https://github.com/GoogleChrome/ioweb2015/issues/597. This works around a race condition we were seeing in the logs and should be safe to use now that `skipWaiting()` is widely available.

Closes https://github.com/GoogleChrome/ioweb2015/issues/597
