### PR TITLE
Set default GAE queue to the maximum

### DIFF
--- a/backend/queue.yaml
+++ b/backend/queue.yaml
@@ -1,0 +1,5 @@
+queue:
+- name: default
+  rate: 500/s
+  bucket_size: 100
+  max_concurrent_requests: 1000


### PR DESCRIPTION
No need to deploy - I aleady updated the queue settings with:

```
appcfg.py update_queues -A io-webapp .
```
