### PR TITLE
Make old /api/ available

### DIFF
--- a/backend/handler.go
+++ b/backend/handler.go
@@ -41,6 +41,8 @@ var (
 // registerHandlers sets up all backend handle funcs, including the API.
 func registerHandlers() {
 	handle("/", rootHandleFn)
+	handle("/api/extended", serveIOExtEntries)
+	handle("/api/social", serveSocial)
 	handle("/api/v1/extended", serveIOExtEntries)
 	handle("/api/v1/social", serveSocial)
 	handle("/api/v1/auth", handleAuth)


### PR DESCRIPTION
Still seeing lots of 404 on `/api/social` and `/api/extended`

R: @ebidel 
