### PR TITLE
Client-side changes for new subscription endpoint response

### DIFF
--- a/app/scripts/helper/notifications.js
+++ b/app/scripts/helper/notifications.js
@@ -95,7 +95,7 @@ IOWA.Notifications = IOWA.Notifications || (function() {
       if (subscription && subscription.endpoint) {
         // See https://groups.google.com/a/chromium.org/d/msg/blink-dev/CK13omVO5ds/fR6sdPxsaasJ
         var endpoint = subscription.endpoint;
-        if ('subscriptionId' in subscription && !endpoint.includes(subscription.subscriptionId)) {
+        if (subscription.subscriptionId && !endpoint.includes(subscription.subscriptionId)) {
           endpoint += '/' + subscription.subscriptionId;
         }
         // If subscribing succeeds, send the subscription to the server. Return a resolved promise.


### PR DESCRIPTION
R: @ebidel, @crhym3, all

@crhym3's changes to create a v2 notify endpoint need to be deployed before/at the same time as this code.

See https://groups.google.com/a/chromium.org/d/msg/blink-dev/CK13omVO5ds/fR6sdPxsaasJ for context, and https://github.com/GoogleChrome/ioweb2015/issues/1116 is the bug tracking this.

This should be backwards compatible with Chrome 42/43, and is required for notifications to work in Chrome 44.
