### PR TITLE
Make .LiveIDs available to all templates

### DIFF
--- a/backend/handler.go
+++ b/backend/handler.go
@@ -41,7 +41,6 @@ var (
 func registerHandlers() {
 	// HTML
 	handle("/", rootHandleFn)
-	handle("/embed", serveEmbed)
 	// API v0 - pre-phase2
 	handle("/api/extended", serveIOExtEntries)
 	handle("/api/social", serveSocial)
@@ -183,21 +182,6 @@ func serveTemplate(w http.ResponseWriter, r *http.Request) {
 	} else {
 		errorf(c, "renderTemplate(%q): %v", tplname, err)
 	}
-}
-
-// serveEmbed responds with the embed gadget HTML.
-func serveEmbed(w http.ResponseWriter, r *http.Request) {
-	c := newContext(r)
-	data := &templateData{}
-	if v, err := scheduleLiveIDs(c); err == nil {
-		data.LiveIDs = v
-	}
-	b, err := renderTemplate(c, "embed", false, data)
-	if err != nil {
-		writeError(w, err)
-		return
-	}
-	w.Write(b)
 }
 
 // serveIOExtEntries responds with I/O extended entries in JSON format.

--- a/backend/handler_test.go
+++ b/backend/handler_test.go
@@ -315,7 +315,7 @@ func TestServeEmbed(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	serveEmbed(w, r)
+	serveTemplate(w, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("w.Code = %d; want 200\nResponse: %s", w.Code, w.Body.String())
 	}

--- a/backend/template.go
+++ b/backend/template.go
@@ -85,6 +85,9 @@ func renderTemplate(c context.Context, name string, partial bool, data *template
 	data.Slug = name
 	data.Prefix = config.Prefix
 	data.StartDateStr = config.Schedule.Start.In(config.Schedule.Location).Format(time.RFC3339)
+	if v, err := scheduleLiveIDs(c); err == nil {
+		data.LiveIDs = v
+	}
 	if data.Desc == "" {
 		data.Desc = descDefault
 	}


### PR DESCRIPTION
@ebidel `<io-live>` should work with this now.
