### PR TITLE
Add upgrade-insecure-requests CSP header

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -41,6 +41,14 @@ func isProd() bool {
 	return config.Env == "prod"
 }
 
+// isDevServer returns true if the app is currently running in a dev server.
+// This is orthogonal to isDev/Staging/Prod. For instance, the app can be running
+// on dev server and be in "prod" mode at the same time. In this case
+// both isProd() and isDevServer() return true.
+func isDevServer() bool {
+	return os.Getenv("RUN_WITH_DEVAPPSERVER") != ""
+}
+
 // appConfig defines the backend config file structure.
 type appConfig struct {
 	// App environment: dev, stage or prod

--- a/backend/handler.go
+++ b/backend/handler.go
@@ -98,7 +98,7 @@ func registerHandlers() {
 	// warmup, can't use prefix
 	http.HandleFunc("/_ah/warmup", func(w http.ResponseWriter, r *http.Request) {
 		c := newContext(r)
-		logf(c, "warmup: env = %s", config.Env)
+		logf(c, "warmup: env = %s; devserver? %v", config.Env, isDevServer())
 	})
 }
 
@@ -181,6 +181,10 @@ func serveTemplate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html;charset=utf-8")
+	if !isDevServer() {
+		w.Header().Set("Content-Security-Policy", "upgrade-insecure-requests")
+	}
+
 	b, err := renderTemplate(c, tplname, wantsPartial, data)
 	if err == nil {
 		w.Header().Set("Cache-Control", "public, max-age=300")

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -320,10 +320,14 @@ gulp.task('pagespeed', pagespeed.bind(null, {
 gulp.task('serve', ['backend', 'backend:config', 'generate-page-metadata', 'generate-data-worker-dev', 'generate-service-worker-dev'], function() {
   var noWatch = argv.watch === false;
   var serverAddr = 'localhost:' + (noWatch ? '3000' : '8080');
-  var start = spawn.bind(null, 'bin/server',
-    ['-addr', serverAddr],
-    {cwd: BACKEND_DIR, stdio: 'inherit'}
-  );
+  var start = function() {
+    var env = process.env;
+    env['RUN_WITH_DEVAPPSERVER'] = '1';
+    return spawn('bin/server',
+      ['-addr', serverAddr],
+      {cwd: BACKEND_DIR, stdio: 'inherit', env: env}
+    );
+  };
 
   if (noWatch) {
     start();


### PR DESCRIPTION
I have tested this: we can currently serve all resources via SSL on stage/prod, no errors. I think it's good to keep it enforced via CSP.

Closes #1057
