### PR TITLE
Use a networkFirst strategy for Picasa

### DIFF
--- a/app/scripts/shed/photo-gallery.js
+++ b/app/scripts/shed/photo-gallery.js
@@ -16,8 +16,9 @@
 
 (function(global) {
   // Use a cache for the Picasa API response for the Google I/O 2014 album.
-  global.shed.router.get('/data/feed/api/user/111395306401981598462/albumid/6029456067262589905(.*)',
-    global.shed.cacheFirst, {origin: /https?:\/\/picasaweb.google.com/});
+  global.shed.router.get('/data/feed/api/user/(.*)',
+    global.shed.networkFirst, {origin: /https?:\/\/picasaweb.google.com/});
   // Use a cache for the actual image files as well.
-  global.shed.router.get('/(.+)', global.shed.cacheFirst, {origin: /https?:\/\/lh\d*.googleusercontent.com/});
+  global.shed.router.get('/(.+)', global.shed.networkFirst,
+    {origin: /https?:\/\/lh\d*.googleusercontent.com/});
 })(self);


### PR DESCRIPTION
R: @ebidel, all

Previously, we just displayed Picasa photos from the 2014 album. It was fine to use a cache-first strategy, since the data would never change.

Now that we've added in support for real-time photos from 2015, we need to attempt to fetch them from the network first to ensure that new pictures are picked up. This will still lead to the expected offline experience, where previously cached pictures will be displayed.
