### PR TITLE
Fixes #1444. Adds a server proxy for picasa api calls

### DIFF
--- a/app/scripts/helper/picasa.js
+++ b/app/scripts/helper/picasa.js
@@ -20,6 +20,7 @@ IOWA.Picasa = (function() {
 
   "use strict";
 
+  var API_ENDPOINT = 'api/v1/photoproxy';
   var GDEVELOPER_USER_ID = '111395306401981598462';
   var ALBUM_ID = '6148448302499535601';
 
@@ -35,8 +36,11 @@ IOWA.Picasa = (function() {
   function fetch(opt_startIndex, callback) {
     var startIndex = opt_startIndex || 1;
 
+    var url = API_ENDPOINT + '?url=' +
+              encodeURIComponent(feedUrl + '&start-index=' + startIndex);
+
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', feedUrl + '&start-index=' + startIndex);
+    xhr.open('GET', url);
     xhr.onload = function(e) {
       if (this.status != 200) {
         return;

--- a/app/scripts/shed/photo-gallery.js
+++ b/app/scripts/shed/photo-gallery.js
@@ -15,9 +15,9 @@
  */
 
 (function(global) {
-  // Use a cache for the Picasa API response for the Google I/O 2014 album.
-  global.shed.router.get('/data/feed/api/user/(.*)',
-    global.shed.networkFirst, {origin: /https?:\/\/picasaweb.google.com/});
+  // Use a cache for the Picasa API response for the Google I/O photo album.
+  // global.shed.router.get('/data/feed/api/user/(.*)',
+  // global.shed.networkFirst, {origin: /https?:\/\/picasaweb.google.com/});
   // Use a cache for the actual image files as well.
   global.shed.router.get('/(.+)', global.shed.networkFirst,
     {origin: /https?:\/\/lh\d*.googleusercontent.com/});

--- a/backend/handler.go
+++ b/backend/handler.go
@@ -67,6 +67,7 @@ func registerHandlers() {
 	handle("/api/v1/auth", handleAuth)
 	handle("/api/v1/schedule", serveSchedule)
 	handle("/api/v1/easter-egg", handleEasterEgg)
+  handle("/api/v1/photoproxy", servePhotosProxy)
 	handle("/api/v1/user/schedule", handleUserSchedule)
 	handle("/api/v1/user/schedule/", handleUserSchedule)
 	handle("/api/v1/user/notify", handleUserNotifySettings)
@@ -1134,6 +1135,36 @@ func serveEasterEgg(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("content-type", "application/json")
 	fmt.Fprintf(w, `{"link": %q}`, link)
+}
+
+// servePhotosProxy serves as a server proxy for Picasa's JSON feeds.
+func servePhotosProxy(w http.ResponseWriter, r *http.Request) {
+	c := newContext(r)
+	if r.Method != "GET" {
+		writeJSONError(c, w, http.StatusBadRequest, "invalid request method")
+		return
+	}
+	url := r.FormValue("url")
+	if !strings.HasPrefix(url, "https://picasaweb.google.com/data/feed/api") {
+		writeJSONError(c, w, http.StatusBadRequest, "url parameter is missing or is an invalid endpoint")
+		return
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		writeJSONError(c, w, errStatus(err), err)
+		return
+	}
+
+	res, err := httpClient(c).Do(req)
+	if err != nil {
+		writeJSONError(c, w, errStatus(err), err)
+		return
+	}
+
+	defer res.Body.Close()
+	w.Header().Set("Content-Type", "application/json;charset=utf-8")
+	w.WriteHeader(res.StatusCode)
+	io.Copy(w, res.Body)
 }
 
 // handleAdmin renders admin home page on 'GET' requests,


### PR DESCRIPTION
R: @crhym3 @jeffposnick 

I wrote some go!

@jeffposnick you're already caching all requests to `api/*`. Is this the only change I need to make for SW?
