### PR TITLE
Explicitly check for the unedited keynote duration.

### DIFF
--- a/app/elements/io-live.html
+++ b/app/elements/io-live.html
@@ -299,7 +299,7 @@ Fired when the mode changes.
         <div class="fullvideo__container" fit>
           <google-youtube videoid="{{selectedVideoId}}" height="100%" width="100%" fit
                           autohide="1" controls="2" modestbranding="1" showinfo="0"
-                          iv_load_policy="3" rel="0" autoplay="1"
+                          iv_load_policy="3" rel="0" autoplay="1" duration="{{duration}}"
                           on-google-youtube-ready="{{onVideoReady}}"
                           on-google-youtube-state-change="{{onStateChange}}"></google-youtube>
         </div>
@@ -533,16 +533,6 @@ Fired when the mode changes.
 
     selectedVideoIdChanged: function() {
       this.selectedVideoId = this.selectedVideoId.replace(/https?:\/\/youtu\.be\//, '');
-
-      // TODO: remove when edited video is ready. This starts the keynote at t=50m28s.
-      if (this.sessions.length) {
-        var keynoteSession = this.sessions[0];
-        var start = keynoteSession.youtubeUrl.match(this.selectedVideoId) ? 3028 : 0;
-        var video = this.$.livecontainer.querySelector('google-youtube');
-        this.async(function() {
-          video.player.seekTo(start);
-        });
-      }
     },
 
     dateChanged: function() {
@@ -840,8 +830,16 @@ Fired when the mode changes.
       var idx = Math.floor((Math.random() * session.speakers.length));
       return this.speakers[session.speakers[idx]].thumbnailUrl ||
              'images/schedule/profile_placeholder.png';
-    }
+    },
 
+    durationChanged: function() {
+      // If this is the unedited Keynote video, the duration should be 10614 seconds.
+      // Skip directly to the 50m28s mark if that's the case.
+      // If this is the edited Keynote video, or any other video, then playback will start at 0s.
+      if (this.duration === 10614) {
+        this.$.livecontainer.querySelector('google-youtube').seekTo(3028);
+      }
+    }
   });
   </script>
 </polymer-element>


### PR DESCRIPTION
R: @ebidel CC: @monicabagagem 

This should catch the unedited keynote's duration and if it sees it, skip to the 50m28s mark. For any other video with a different duration, included the edited keynote, it will start playback at 0s.
