### PR TITLE
Setup the env before spawn the go server, fix #1513

### DIFF
--- a/gulp_scripts/backend.js
+++ b/gulp_scripts/backend.js
@@ -113,7 +113,10 @@ function serve(opts, callback) {
 
   var proc;
   var spawnBackend = function() {
-    proc = spawn('bin/server', ['-addr', serverAddr], {cwd: opts.dir, stdio: 'inherit'});
+    var env = process.env;
+    env['RUN_WITH_DEVAPPSERVER'] = '1';
+    proc = spawn('bin/server', ['-addr', serverAddr],
+                 {cwd: opts.dir, stdio: 'inherit', env: env});
   };
 
   spawnBackend();


### PR DESCRIPTION
Sorry, seems to mess up with the previous pull request.

I think there should be a check for --env=prod/stage/dev before setup the env variable; but I didn't find a easy way to get that `--env` variable. 