### PR TITLE
Fix bower dep versions

### DIFF
--- a/app/bower.json
+++ b/app/bower.json
@@ -73,6 +73,8 @@
   },
   "resolutions": {
     "web-animations-js": "1.0.7",
-    "webcomponentsjs": "^0.6.1"
+    "webcomponentsjs": "^0.6.1",
+    "google-apis": "^0.4.4",
+    "polymer": "^0.5.6"
   }
 }


### PR DESCRIPTION
While trying to [migrate to a public ci](https://travis-ci.org/GoogleChrome/ioweb2015/builds/65869500) I discovered that a fresh `gulp bower` doesn't work anymore.
This change should fix it.

@ebidel 